### PR TITLE
Matrix empty filter sticky header

### DIFF
--- a/packages/ketchup-showcase/src/App.vue
+++ b/packages/ketchup-showcase/src/App.vue
@@ -324,4 +324,15 @@ kup-fld {
   display: inline-flex;
   padding: 12px;
 }
+
+// For tables
+kup-data-table {
+
+  --kup-data-table_box-shadow: 0px 0px 7.5px -7.5px rgba(128, 128, 128, 0.5);
+  --kup-data-table_header-offset: 64px;
+
+  @media only screen and (max-width: 959px) {
+    --kup-data-table_header-offset: 55px;
+  }
+}
 </style>

--- a/packages/ketchup-showcase/src/App.vue
+++ b/packages/ketchup-showcase/src/App.vue
@@ -311,6 +311,12 @@ select,
   }
 }
 
+// A scrollable container which can be used to perform test on some components.
+.scrollable-container {
+  height: 400px;
+  overflow: auto;
+}
+
 // When there is the need to hide overflow
 .hide-overflow {
   overflow: hidden;
@@ -327,8 +333,7 @@ kup-fld {
 
 // For tables
 kup-data-table {
-
-  --kup-data-table_box-shadow: 0px 0px 7.5px -7.5px rgba(128, 128, 128, 0.5);
+  // These pixels measurement are taken from the height of the toolbar of the vuetify webapp.
   --kup-data-table_header-offset: 64px;
 
   @media only screen and (max-width: 959px) {

--- a/packages/ketchup-showcase/src/views/dataTable/DTBasic.vue
+++ b/packages/ketchup-showcase/src/views/dataTable/DTBasic.vue
@@ -27,6 +27,9 @@ h3 {
     <h3>Without header</h3>
     <kup-data-table :data.prop="data" :showHeader.prop="false"></kup-data-table>
 
+    <h3>Persistent header (sticky)</h3>
+    <kup-data-table :data.prop="iconImagesDataTable" header-is-persistent></kup-data-table>
+
     <h3>Without grid</h3>
     <kup-data-table :data.prop="data" :showGrid.prop="false"></kup-data-table>
 

--- a/packages/ketchup-showcase/src/views/dataTable/DTBasic.vue
+++ b/packages/ketchup-showcase/src/views/dataTable/DTBasic.vue
@@ -30,6 +30,13 @@ h3 {
     <h3>Persistent header (sticky)</h3>
     <kup-data-table :data.prop="iconImagesDataTable" header-is-persistent></kup-data-table>
 
+    <h3>Persistent header (sticky) - Inside a scrollable container</h3>
+    <div class="scrollable-container persistent-header-wrapper">
+      <kup-data-table :data.prop="iconImagesDataTable" header-is-persistent></kup-data-table>
+      <kup-data-table :data.prop="iconImagesDataTable" header-is-persistent></kup-data-table>
+      <kup-data-table :data.prop="iconImagesDataTable" header-is-persistent></kup-data-table>
+    </div>
+
     <h3>Without grid</h3>
     <kup-data-table :data.prop="data" :showGrid.prop="false"></kup-data-table>
 
@@ -80,3 +87,11 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.persistent-header-wrapper {
+  kup-data-table {
+    --kup-data-table_header-offset: 0;
+  }
+}
+</style>

--- a/packages/ketchup-showcase/src/views/dataTable/DTFilters.vue
+++ b/packages/ketchup-showcase/src/views/dataTable/DTFilters.vue
@@ -31,6 +31,20 @@ h3 {
       :globalFilter.prop="true"
       :filters.prop="filters"
     ></kup-data-table>
+
+    <h3>Column filter with empty value</h3>
+    <kup-data-table
+      :data.prop="dataTableWithEmptyValues"
+      :showFilters.prop="true"
+      :filters.prop="filtersEmpty"
+    ></kup-data-table>
+
+    <h3>Column and global filter with empty value</h3>
+    <kup-data-table
+      :data.prop="dataTableWithEmptyValues"
+      :showFilters.prop="true"
+      :globalFilter.prop="true"
+    ></kup-data-table>
   </div>
 </template>
 
@@ -41,13 +55,23 @@ export default {
   name: 'dataTableFilters',
 
   data() {
+    let dataTableWithEmptyValues = {
+      ...defaultDataTable
+    };
+
+    dataTableWithEmptyValues.rows[0].cells.FLD1.value = '';
+
     return {
       data: {
         ...defaultDataTable,
       },
+      dataTableWithEmptyValues,
       filters: {
         FLD1: 'FRA',
       },
+      filtersEmpty: {
+        FLD1: "''",
+      }
     };
   },
 };

--- a/packages/ketchup/package-lock.json
+++ b/packages/ketchup/package-lock.json
@@ -1710,12 +1710,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1730,17 +1732,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1857,7 +1862,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1869,6 +1875,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1883,6 +1890,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1890,12 +1898,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1914,6 +1924,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1994,7 +2005,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2006,6 +2018,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2127,6 +2140,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -163,6 +163,10 @@ export namespace Components {
     'filters': GenericMap;
     'globalFilter': boolean;
     'groups': Array<GroupObject>;
+    /**
+    * If table header is visible and this prop is set to true, the header will be visible while scrolling the table. To make this work, it must be configured together with the data-table CSS property --kup-data-table_header-offset. It uses CSS position: sticky.
+    */
+    'headerIsPersistent': boolean;
     'multiSelection': boolean;
     'paginatorPos': PaginatorPos;
     'rowActions': Array<RowAction>;
@@ -170,6 +174,9 @@ export namespace Components {
     'selectRow': number;
     'showFilters': boolean;
     'showGrid': ShowGrid;
+    /**
+    * Enables rendering of the table header.
+    */
     'showHeader': boolean;
     'sort': Array<SortObject>;
     'sortEnabled': boolean;
@@ -665,6 +672,10 @@ declare namespace LocalJSX {
     'filters'?: GenericMap;
     'globalFilter'?: boolean;
     'groups'?: Array<GroupObject>;
+    /**
+    * If table header is visible and this prop is set to true, the header will be visible while scrolling the table. To make this work, it must be configured together with the data-table CSS property --kup-data-table_header-offset. It uses CSS position: sticky.
+    */
+    'headerIsPersistent'?: boolean;
     'multiSelection'?: boolean;
     /**
     * When 'add column' menu item is clicked
@@ -705,6 +716,9 @@ declare namespace LocalJSX {
     'selectRow'?: number;
     'showFilters'?: boolean;
     'showGrid'?: ShowGrid;
+    /**
+    * Enables rendering of the table header.
+    */
     'showHeader'?: boolean;
     'sort'?: Array<SortObject>;
     'sortEnabled'?: boolean;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
@@ -128,6 +128,21 @@ function compareRows(r1: Row, r2: Row, sortObj: SortObject): number {
     return compareCell(cell1, cell2, sortObj.sortMode);
 }
 
+//-------- FILTER FUNCTIONS --------
+/**
+ * Given a cell value and a filter value, returns if that cell (and therefore its row) should be displayed if
+ * both values are empty.
+ * @param cellValue - The value of the current cell.
+ * @param currentFilter - The value of the current filter.
+ * @returns True if the filter is empty and the value of the cell is empty, false otherwise.
+ */
+function matchEmptyFilter(cellValue: string, currentFilter: string):boolean {
+    const parsedFilter = currentFilter.trim();
+    // TODO uncomment this if a filter composed of white space characters can be used to specify a cell with blank value.
+    return (/* !parsedFilter ||*/ parsedFilter === "''") && !cellValue.trim();
+}
+
+
 export function filterRows(
     rows: Array<Row> = [],
     filters: GenericMap = {},
@@ -166,7 +181,8 @@ export function filterRows(
                     if (
                         cellValue
                             .toLowerCase()
-                            .includes(globalFilter.toLocaleLowerCase())
+                            .includes(globalFilter.toLocaleLowerCase()) ||
+                        matchEmptyFilter(cellValue, globalFilter)
                     ) {
                         found = true;
                         break;
@@ -188,14 +204,15 @@ export function filterRows(
 
                     // getting cell value
                     const cellValue = r.cells[key];
-                    if (!cellValue || !cellValue.value) {
+                    if (!cellValue) {
                         return false;
                     }
 
                     if (
                         cellValue.value
                             .toLowerCase()
-                            .includes(filterValue.toLowerCase())
+                            .includes(filterValue.toLowerCase()) ||
+                        matchEmptyFilter(cellValue.value, filterValue)
                     ) {
                         return true;
                     }

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.scss
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.scss
@@ -9,33 +9,34 @@
 :host {
   // variables
   --int_background-color: var(--kup-data-table_background-color, #ffffff);
-  --int_main-color: var(--kup-data-table_main-color, #6aaaa7);
-  --int_text-on-main-color: var(--kup-data-table_text-on-main-color, #ffffff);
-  --int_color: var(--kup-data-table_color, #545454);
-  --int_stronger-color: var(--kup-data-table_stronger-color, #111111);
-  --int_hover-color: var(--kup-data-table_hover-color, #545454);
-  --int_hover-background-color: var(
-    --kup-data-table_hover-background-color,
-    #e0e0e0
-  );
   --int_border-color: var(--kup-data-table_border-color, #000000);
+  --int_box-shadow: var(
+      --kup-data-table_box-shadow,
+      0px 0px 7.5px 0px rgba(128, 128, 128, 0.5)
+  );
+  --int_color: var(--kup-data-table_color, #545454);
+  --int_filter-border-color: var(--kup-data-table_filter-border-color, #dadada);
+  --int_group-background-color: var(
+      --kup-data-table_group-background-color,
+      #f5f5f5
+  );
+  --int_group-border-color: var(--kup-data-table_group-border-color, #6aaaa7);
+  --int_hover-color: var(--kup-data-table_hover-color, #545454);
   --int_head-background-color: var(
     --kup-data-table_head-background-color,
     #f5f5f5
   );
-  --int_group-background-color: var(
-    --kup-data-table_group-background-color,
-    #f5f5f5
+  --int_header-offset: var(--kup-data-table_header-offset, 50px);
+  --int_hover-background-color: var(
+    --kup-data-table_hover-background-color,
+    #e0e0e0
   );
-  --int_group-border-color: var(--kup-data-table_group-border-color, #6aaaa7);
-  --int_filter-border-color: var(--kup-data-table_filter-border-color, #dadada);
   --int_icons-color: var(--kup-data-table_icons-color, #808080);
   --int_icons-hover-color: var(--kup-data-table_icons-hover-color, #a0a0a0);
-  --int_box-shadow: var(
-    --kup-data-table_box-shadow,
-    0px 0px 7.5px 0px rgba(128, 128, 128, 0.5)
-  );
   --int_font-size: var(--kup-data-table_font-size, 1rem);
+  --int_main-color: var(--kup-data-table_main-color, #6aaaa7);
+  --int_stronger-color: var(--kup-data-table_stronger-color, #111111);
+  --int_text-on-main-color: var(--kup-data-table_text-on-main-color, #ffffff);
 }
 
 #data-table-wrapper {
@@ -99,6 +100,38 @@
 
       th {
         position: relative;
+      }
+    }
+
+    /**
+     * When the header must be persistent (sticky)
+     * There is an issue with borders not being moved alongside the content.
+     * To prevent horrible renders we move border declarations on other elements
+     * Border top gets set on the table itself.
+     * thead hosts the lateral borders.
+     * tbody sets border-top.
+     * Header cells get set to sticky positioning.
+     */
+    &.persistent-header {
+      border-top: 1px solid var(--int_border-color);
+      position: relative;
+
+      thead {
+        border-color: var(--int_border-color);
+        border-style: solid;
+        border-width: 0 1px 0;
+
+        th {
+          background-color: var(--int_head-background-color);
+          box-shadow: var(--int_box-shadow);
+          position: -webkit-sticky; // For Safari
+          position: sticky;
+          top: var(--int_header-offset);
+        }
+      }
+
+      tbody {
+        border-top: 3px solid var(--int_border-color);
       }
     }
 

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.scss
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.scss
@@ -1,9 +1,23 @@
 @import url(https://cdn.materialdesignicons.com/3.6.95/css/materialdesignicons.min.css);
 
 /**
-* @prop --int_stronger-color, --kup-data-table_stronger-color: Set text color
-* @prop --int_hover-color, --kup-data-table_hover-color: Set text color when hover on row
-* @prop --int_hover-background-color, --kup-data-table_hover-background-color: Set background color when hover on row
+* @prop --int_background-color, --kup-data-table_background-color: background-color of the whole component (paginator and table).
+* @prop --int_border-color, --kup-data-table_border-color: border-color for the whole table.
+* @prop --int_box-shadow, --kup-data-table_box-shadow: common box-shadow used by the table.
+* @prop --int_color, --kup-data-table_color: Text color of the column menu when hovering a header cell.
+* @prop --int_filter-border-color, --kup-data-table_filter-border-color: Sets border color onto kup-text-input elements used to filter rows.
+* @prop --int_group-background-color, --kup-data-table_group-background-color: background-color when grouping elements.
+* @prop --int_group-border-color, --kup-data-table_group-border-color: TODO check where used.
+* @prop --int_hover-color, --kup-data-table_hover-color: text color of a row when it's selected or hovered.
+* @prop --int_head-background-color, --kup-data-table_head-background-color: Background color of the table header.
+* @prop --int_header-offset, --kup-data-table_header-offset: Top offset of the thead when table header must be persistent. Default: 50px;
+* @prop --int_hover-background-color, --kup-data-table_hover-background-color: background-color of a row when it's selected or hovered.
+* @prop --int_icons-color, --kup-data-table_icons-color: Color of a table icon.
+* @prop --int_icons-hover-color, --kup-data-table_icons-hover-color: Color of a hovered icon.
+* @prop --int_font-size, --kup-data-table_font-size: Sets basic font size.
+* @prop --int_main-color, --kup-data-table_main-color: Set text color. Has the precedence.
+* @prop --int_stronger-color, --kup-data-table_stronger-color: Set text color on the whole table element.
+* @prop --int_text-on-main-color, --kup-data-table_text-on-main-color: Color of the grouping chips of a column.
 */
 
 :host {
@@ -127,6 +141,7 @@
           position: -webkit-sticky; // For Safari
           position: sticky;
           top: var(--int_header-offset);
+          will-change: transform; // For performance
         }
       }
 

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -77,8 +77,24 @@ export class KupDataTable {
         width: number;
     }> = [];
 
+    /**
+     * Enables rendering of the table header.
+     * @namespace KupDataTable.showHeader
+     */
     @Prop()
     showHeader = true;
+
+    /**
+     * If table header is visible and this prop is set to true, the header will be visible while scrolling the table.
+     * To make this work, it must be configured together with the data-table CSS property --kup-data-table_header-offset.
+     * It uses CSS position: sticky.
+     * @version 1.0
+     * @namespace KupDataTable.headerIsPersistent
+     * @see KupDataTable.showHeader
+     * @see https://caniuse.com/#feat=css-sticky
+     */
+    @Prop({ reflect: true })
+    headerIsPersistent = false;
 
     @Prop()
     showGrid: ShowGrid = ShowGrid.NONE;
@@ -1402,6 +1418,8 @@ export class KupDataTable {
             'row-separation':
                 ShowGrid.COMPLETE === this.showGrid ||
                 ShowGrid.ROW === this.showGrid,
+
+            'persistent-header': this.headerIsPersistent,
         };
 
         tableClass[`density-${this.density}`] = true;

--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -2,30 +2,70 @@
 
 
 
+## About persistent header
+
+A persistent header is when the header of the table remains positioned fixedly and is visible when a user
+scrolls the window until the whole table has disappeared from view.
+
+The current implementation, based on the features of the currently used SmeUP data table component,
+make use of the CSS property `position: sticky;`.
+[Here](https://caniuse.com/#feat=css-sticky) you can see the support fot this feature.
+
+The implementation of this feature makes use of pure CSS because its current behavior is quite simple.
+
+More details about the component's modification to allow sticky positioning can be found inside the comments
+left in the component itself.
+
+To see how to configure this behavior, check out the `header-is-persistent` property.
+
+#### Known limitations
+
+##### Table headers borders
+
+Browsers tables has always been problematic.
+Due to how browsers implements the `sticky` feature, when applied to a `<th>` element inside a `<thead>`,
+the borders do not get scrolled down: they stay in their original position.
+
+In other words, if you need to set border between header cells, your best call would be to either use the
+`:before` or `after` pseudo elements positioned absolutely inside each cell.
+Or set the border to a wrapper which is also the first children of the cell itself.
+
+This helps you solve also other problems with `<th>` elements having a transparent border set when scrolling.
+A border you cannot get rid of.
+
+##### The `sticky` behavior is relative to an element first scrollable ancestor
+
+The `sticky` behavior gets triggered when the first ancestor element with a scrollable content gets scrolled.
+
+If the `sticky` element would be hidden by the scroll, after having specified a threshold (top, bottom, left, right),
+the element gets positioned fixedly until its ancestor is fully scrolled: in that moment it stops from being fixed and disappears.
+
+
 <!-- Auto Generated Below -->
 
 
 ## Properties
 
-| Property         | Attribute         | Description | Type                                                                 | Default            |
-| ---------------- | ----------------- | ----------- | -------------------------------------------------------------------- | ------------------ |
-| `columnsWidth`   | --                |             | `{ column: string; width: number; }[]`                               | `[]`               |
-| `data`           | --                |             | `{ columns?: Column[]; rows?: Row[]; }`                              | `undefined`        |
-| `expandGroups`   | `expand-groups`   |             | `boolean`                                                            | `false`            |
-| `filters`        | --                |             | `GenericMap`                                                         | `{}`               |
-| `globalFilter`   | `global-filter`   |             | `boolean`                                                            | `false`            |
-| `groups`         | --                |             | `GroupObject[]`                                                      | `[]`               |
-| `multiSelection` | `multi-selection` |             | `boolean`                                                            | `false`            |
-| `paginatorPos`   | `paginator-pos`   |             | `PaginatorPos.BOTH \| PaginatorPos.BOTTOM \| PaginatorPos.TOP`       | `PaginatorPos.TOP` |
-| `rowActions`     | --                |             | `RowAction[]`                                                        | `undefined`        |
-| `rowsPerPage`    | `rows-per-page`   |             | `number`                                                             | `10`               |
-| `selectRow`      | `select-row`      |             | `number`                                                             | `undefined`        |
-| `showFilters`    | `show-filters`    |             | `boolean`                                                            | `false`            |
-| `showGrid`       | `show-grid`       |             | `ShowGrid.COL \| ShowGrid.COMPLETE \| ShowGrid.NONE \| ShowGrid.ROW` | `ShowGrid.NONE`    |
-| `showHeader`     | `show-header`     |             | `boolean`                                                            | `true`             |
-| `sort`           | --                |             | `SortObject[]`                                                       | `[]`               |
-| `sortEnabled`    | `sort-enabled`    |             | `boolean`                                                            | `true`             |
-| `totals`         | --                |             | `TotalsMap`                                                          | `undefined`        |
+| Property             | Attribute              | Description                                                                                                                                                                                                                                                     | Type                                                                 | Default            |
+| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------ |
+| `columnsWidth`       | --                     |                                                                                                                                                                                                                                                                 | `{ column: string; width: number; }[]`                               | `[]`               |
+| `data`               | --                     |                                                                                                                                                                                                                                                                 | `{ columns?: Column[]; rows?: Row[]; }`                              | `undefined`        |
+| `expandGroups`       | `expand-groups`        |                                                                                                                                                                                                                                                                 | `boolean`                                                            | `false`            |
+| `filters`            | --                     |                                                                                                                                                                                                                                                                 | `GenericMap`                                                         | `{}`               |
+| `globalFilter`       | `global-filter`        |                                                                                                                                                                                                                                                                 | `boolean`                                                            | `false`            |
+| `groups`             | --                     |                                                                                                                                                                                                                                                                 | `GroupObject[]`                                                      | `[]`               |
+| `headerIsPersistent` | `header-is-persistent` | If table header is visible and this prop is set to true, the header will be visible while scrolling the table. To make this work, it must be configured together with the data-table CSS property --kup-data-table_header-offset. It uses CSS position: sticky. | `boolean`                                                            | `false`            |
+| `multiSelection`     | `multi-selection`      |                                                                                                                                                                                                                                                                 | `boolean`                                                            | `false`            |
+| `paginatorPos`       | `paginator-pos`        |                                                                                                                                                                                                                                                                 | `PaginatorPos.BOTH \| PaginatorPos.BOTTOM \| PaginatorPos.TOP`       | `PaginatorPos.TOP` |
+| `rowActions`         | --                     |                                                                                                                                                                                                                                                                 | `RowAction[]`                                                        | `undefined`        |
+| `rowsPerPage`        | `rows-per-page`        |                                                                                                                                                                                                                                                                 | `number`                                                             | `10`               |
+| `selectRow`          | `select-row`           |                                                                                                                                                                                                                                                                 | `number`                                                             | `undefined`        |
+| `showFilters`        | `show-filters`         |                                                                                                                                                                                                                                                                 | `boolean`                                                            | `false`            |
+| `showGrid`           | `show-grid`            |                                                                                                                                                                                                                                                                 | `ShowGrid.COL \| ShowGrid.COMPLETE \| ShowGrid.NONE \| ShowGrid.ROW` | `ShowGrid.NONE`    |
+| `showHeader`         | `show-header`          | Enables rendering of the table header.                                                                                                                                                                                                                          | `boolean`                                                            | `true`             |
+| `sort`               | --                     |                                                                                                                                                                                                                                                                 | `SortObject[]`                                                       | `[]`               |
+| `sortEnabled`        | `sort-enabled`         |                                                                                                                                                                                                                                                                 | `boolean`                                                            | `true`             |
+| `totals`             | --                     |                                                                                                                                                                                                                                                                 | `TotalsMap`                                                          | `undefined`        |
 
 
 ## Events
@@ -41,11 +81,25 @@
 
 ## CSS Custom Properties
 
-| Name                                                                    | Description                            |
-| ----------------------------------------------------------------------- | -------------------------------------- |
-| `--int_hover-background-color, --kup-data-table_hover-background-color` | Set background color when hover on row |
-| `--int_hover-color, --kup-data-table_hover-color`                       | Set text color when hover on row       |
-| `--int_stronger-color, --kup-data-table_stronger-color`                 | Set text color                         |
+| Name                                                                    | Description                                                                  |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `--int_background-color, --kup-data-table_background-color`             | background-color of the whole component (paginator and table).               |
+| `--int_border-color, --kup-data-table_border-color`                     | border-color for the whole table.                                            |
+| `--int_box-shadow, --kup-data-table_box-shadow`                         | common box-shadow used by the table.                                         |
+| `--int_color, --kup-data-table_color`                                   | Text color of the column menu when hovering a header cell.                   |
+| `--int_filter-border-color, --kup-data-table_filter-border-color`       | Sets border color onto kup-text-input elements used to filter rows.          |
+| `--int_font-size, --kup-data-table_font-size`                           | Sets basic font size.                                                        |
+| `--int_group-background-color, --kup-data-table_group-background-color` | background-color when grouping elements.                                     |
+| `--int_group-border-color, --kup-data-table_group-border-color`         | TODO check where used.                                                       |
+| `--int_head-background-color, --kup-data-table_head-background-color`   | Background color of the table header.                                        |
+| `--int_header-offset, --kup-data-table_header-offset`                   | Top offset of the thead when table header must be persistent. Default: 50px; |
+| `--int_hover-background-color, --kup-data-table_hover-background-color` | background-color of a row when it's selected or hovered.                     |
+| `--int_hover-color, --kup-data-table_hover-color`                       | text color of a row when it's selected or hovered.                           |
+| `--int_icons-color, --kup-data-table_icons-color`                       | Color of a table icon.                                                       |
+| `--int_icons-hover-color, --kup-data-table_icons-hover-color`           | Color of a hovered icon.                                                     |
+| `--int_main-color, --kup-data-table_main-color`                         | Set text color. Has the precedence.                                          |
+| `--int_stronger-color, --kup-data-table_stronger-color`                 | Set text color on the whole table element.                                   |
+| `--int_text-on-main-color, --kup-data-table_text-on-main-color`         | Color of the grouping chips of a column.                                     |
 
 
 ## Dependencies

--- a/packages/ketchup/src/components/kup-html/kup-html.tsx
+++ b/packages/ketchup/src/components/kup-html/kup-html.tsx
@@ -20,7 +20,7 @@ export class KupHtml {
      * If true, the kup-html takes the shape of a button
      */
     @Prop({
-        reflectToAttr: true
+        reflect: true
     }) isButton: boolean = false;
     /**
      * The address which must be referenced by the iframe

--- a/packages/ketchup/src/components/kup-portal-instance/kup-portal-instance.tsx
+++ b/packages/ketchup/src/components/kup-portal-instance/kup-portal-instance.tsx
@@ -16,7 +16,7 @@ export class KupPortalInstance {
     /**
      * Specifies if the current portal instance should be displayed or not.
      */
-    @Prop({ reflectToAttr: true }) isVisible: boolean = false;
+    @Prop({ reflect: true }) isVisible: boolean = false;
     /**
      * A style node to be copied into the KetchupPortalInstance
      */

--- a/packages/ketchup/tests/e2e/data-table/data-table-basic.e2e.ts
+++ b/packages/ketchup/tests/e2e/data-table/data-table-basic.e2e.ts
@@ -124,6 +124,11 @@ describe('kup-data-table', () => {
     });
 
     it('cell has right click button', async (done) => {
+        /* TODO this test some time fails due to a strange error which seems to be caused by Puppeteer itself.
+        * @see https://github.com/ionic-team/stencil/issues/1297
+        * No fix still found.
+        **/
+
         const page = await newE2EPage();
 
         await page.setContent('<kup-data-table></kup-data-table>');

--- a/packages/ketchup/tests/unit/data-table/data-table-filter.spec.ts
+++ b/packages/ketchup/tests/unit/data-table/data-table-filter.spec.ts
@@ -1,223 +1,231 @@
 import { filterRows } from '../../../src/components/kup-data-table/kup-data-table-helper';
 
-const mockedRows = [
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'CASFRA',
+function MockedRowsFactory() {
+    return [
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'CASFRA',
+                    },
+                    value: 'CASFRA',
                 },
-                value: 'CASFRA',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '12',
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '12',
+                    },
+                    value: '12',
                 },
-                value: '12',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '100.60',
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '100.60',
+                    },
+                    value: '100.60',
                 },
-                value: '100.60',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180101',
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180101',
+                    },
+                    value: '01/01/2018',
                 },
-                value: '01/01/2018',
-            },
-        },
-    },
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'DELGIO',
-                },
-                value: 'DELGIO',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '8',
-                },
-                value: '8',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '67.8',
-                },
-                value: '67.8',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180102',
-                },
-                value: '02/01/2018',
             },
         },
-    },
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'PARFRA',
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'DELGIO',
+                    },
+                    value: 'DELGIO',
                 },
-                value: 'PARFRA',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '7',
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '8',
+                    },
+                    value: '8',
                 },
-                value: '7',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '120.06',
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '67.8',
+                    },
+                    value: '67.8',
                 },
-                value: '120.06',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180103',
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180102',
+                    },
+                    value: '02/01/2018',
                 },
-                value: '03/01/2018',
-            },
-        },
-    },
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'CASFRA',
-                },
-                value: 'CASFRA',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '10',
-                },
-                value: '10',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '100.60',
-                },
-                value: '100.60',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180101',
-                },
-                value: '01/01/2018',
             },
         },
-    },
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'DELGIO',
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'PARFRA',
+                    },
+                    value: 'PARFRA',
                 },
-                value: 'DELGIO',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '6',
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '7',
+                    },
+                    value: '7',
                 },
-                value: '6',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '67.8',
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '120.06',
+                    },
+                    value: '120.06',
                 },
-                value: '67.8',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180102',
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180103',
+                    },
+                    value: '03/01/2018',
                 },
-                value: '02/01/2018',
-            },
-        },
-    },
-    {
-        cells: {
-            FLD1: {
-                obj: {
-                    t: 'CN',
-                    p: 'COL',
-                    k: 'PARFRA',
-                },
-                value: 'PARFRA',
-            },
-            FLD2: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '5',
-                },
-                value: '5',
-            },
-            FLD3: {
-                obj: {
-                    t: 'NR',
-                    p: '',
-                    k: '120.06',
-                },
-                value: '120.06',
-            },
-            FLD4: {
-                obj: {
-                    t: 'D8',
-                    p: '*YYMD',
-                    k: '20180103',
-                },
-                value: '03/01/2018',
             },
         },
-    },
-];
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'CASFRA',
+                    },
+                    value: 'CASFRA',
+                },
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '10',
+                    },
+                    value: '10',
+                },
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '100.60',
+                    },
+                    value: '100.60',
+                },
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180101',
+                    },
+                    value: '01/01/2018',
+                },
+            },
+        },
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'DELGIO',
+                    },
+                    value: 'DELGIO',
+                },
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '6',
+                    },
+                    value: '6',
+                },
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '67.8',
+                    },
+                    value: '67.8',
+                },
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180102',
+                    },
+                    value: '02/01/2018',
+                },
+            },
+        },
+        {
+            cells: {
+                FLD1: {
+                    obj: {
+                        t: 'CN',
+                        p: 'COL',
+                        k: 'PARFRA',
+                    },
+                    value: 'PARFRA',
+                },
+                FLD2: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '5',
+                    },
+                    value: '5',
+                },
+                FLD3: {
+                    obj: {
+                        t: 'NR',
+                        p: '',
+                        k: '120.06',
+                    },
+                    value: '120.06',
+                },
+                FLD4: {
+                    obj: {
+                        t: 'D8',
+                        p: '*YYMD',
+                        k: '20180103',
+                    },
+                    value: '03/01/2018',
+                },
+            },
+        },
+    ];
+}
+
+const mockedRows = MockedRowsFactory();
+
+const mockedRowsWithEmptyValues = MockedRowsFactory();
+mockedRowsWithEmptyValues[0].cells.FLD1.value = '';
+mockedRowsWithEmptyValues[2].cells.FLD1.value = '';
 
 describe('it filters rows', () => {
     it('filter without parameters', () => {
@@ -310,5 +318,23 @@ describe('it filters rows', () => {
         expect(filtered).not.toEqual(mockedRows);
 
         expect(filtered).toHaveLength(1);
+    });
+
+    describe('with filter set to \'\'', () => {
+
+        const columnToFilterOn = 'FLD1';
+
+        it('on column filter', () => {
+            const filtered = filterRows(
+              mockedRowsWithEmptyValues,
+              {[columnToFilterOn]: "''"}
+            );
+
+            expect(filtered).toHaveLength(2);
+            filtered.forEach(row => {
+                expect(row.cells[columnToFilterOn].value).toBe('');
+            })
+
+        });
     });
 });

--- a/packages/ketchup/tests/unit/data-table/data-table-filter.spec.ts
+++ b/packages/ketchup/tests/unit/data-table/data-table-filter.spec.ts
@@ -336,5 +336,20 @@ describe('it filters rows', () => {
             })
 
         });
+
+        it('on global column filter', () => {
+            const filtered = filterRows(
+              mockedRowsWithEmptyValues,
+              {},
+              "''",
+              ['FLD1', 'FLD2', 'FLD3', 'FLD4']
+            );
+
+            expect(filtered).toHaveLength(2);
+            filtered.forEach(row => {
+                expect(row.cells[columnToFilterOn].value).toBe('');
+            })
+
+        });
     });
 });


### PR DESCRIPTION
Added sticky header functionality for the table header.
Added control on filter functionality to show cells with null values when filter is set to `''`.

@casetta-smeup there is a strange error not always occurring when running `data-table-basic.e2e.ts > 'cell has right click button'`. Can you tell me if this test some times fails also for you?