### PR TITLE
CSS Classes for box

### DIFF
--- a/packages/ketchup-showcase/src/views/box/BoxClasses.vue
+++ b/packages/ketchup-showcase/src/views/box/BoxClasses.vue
@@ -2,6 +2,8 @@
   <div>
     <h3>no-shadow</h3>
     <kup-box :data.prop="basicData" class="no-shadow"></kup-box>
+    <h3>with-padding</h3>
+    <kup-box :data.prop="basicData" class="with-padding"></kup-box>
   </div>
 </template>
 

--- a/packages/ketchup/src/components/kup-badge/readme.md
+++ b/packages/ketchup/src/components/kup-badge/readme.md
@@ -28,8 +28,8 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-image](../kup-image)
+ - [kup-box](..\kup-box)
+ - [kup-image](..\kup-image)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-box/kup-box.scss
+++ b/packages/ketchup/src/components/kup-box/kup-box.scss
@@ -59,7 +59,6 @@
       border-radius: var(--box_border-radius);
       border: 1px solid var(--box_border-color);
       display: flex;
-      padding: 3px;
 
       &.column {
         flex-direction: column;
@@ -76,10 +75,6 @@
         flex: 1 1 1%;
         flex-wrap: wrap;
 
-        &.last-child {
-          margin: 3px 4px;
-        }
-
         &.column {
           flex-direction: column;
           justify-content: center;
@@ -95,8 +90,6 @@
         }
 
         .box-object {
-          padding: 1px 4px;
-
           img {
             border-radius: var(--box_img-border-radius);
             height: auto;

--- a/packages/ketchup/src/components/kup-box/kup-box.scss
+++ b/packages/ketchup/src/components/kup-box/kup-box.scss
@@ -60,6 +60,20 @@
       border: 1px solid var(--box_border-color);
       display: flex;
 
+      &.with-padding {
+        padding: 3px;
+
+        .box-section {
+          .box-object {
+            padding: 1px 4px;
+          }
+
+          &.last-child {
+            margin: 3px 4px;
+          }
+        }
+      }
+
       &.column {
         flex-direction: column;
       }
@@ -89,7 +103,36 @@
           display: grid;
         }
 
+        &.center-aligned {
+          text-align: center;
+          kup-image,
+          kup-checkbox {
+            justify-content: center;
+          }
+        }
+
+        &.left-aligned {
+          text-align: left;
+          kup-image,
+          kup-checkbox {
+            justify-content: flex-start;
+          }
+        }
+
+        &.right-aligned {
+          text-align: right;
+          kup-image,
+          kup-checkbox {
+            justify-content: flex-end;
+          }
+        }
+
         .box-object {
+          kup-image,
+          kup-checkbox {
+            display: flex;
+          }
+
           img {
             border-radius: var(--box_img-border-radius);
             height: auto;

--- a/packages/ketchup/src/components/kup-box/kup-box.scss
+++ b/packages/ketchup/src/components/kup-box/kup-box.scss
@@ -60,20 +60,6 @@
       border: 1px solid var(--box_border-color);
       display: flex;
 
-      &.with-padding {
-        padding: 3px;
-
-        .box-section {
-          .box-object {
-            padding: 1px 4px;
-          }
-
-          &.last-child {
-            margin: 3px 4px;
-          }
-        }
-      }
-
       &.column {
         flex-direction: column;
       }
@@ -287,6 +273,24 @@
       &:hover,
       &.selected {
         box-shadow: none;
+      }
+    }
+  }
+}
+
+:host(.with-padding) {
+  #box-container {
+    .box {
+      padding: 3px;
+
+      .box-section {
+        .box-object {
+          padding: 1px 4px;
+        }
+
+        &.last-child {
+          margin: 3px 4px;
+        }
       }
     }
   }

--- a/packages/ketchup/src/components/kup-box/readme.md
+++ b/packages/ketchup/src/components/kup-box/readme.md
@@ -70,15 +70,15 @@ Type: `Promise<void>`
 
 ### Depends on
 
-- [kup-badge](../kup-badge)
-- [kup-image](../kup-image)
-- [kup-button](../kup-button)
-- [kup-checkbox](../kup-checkbox)
-- [kup-radio](../kup-radio)
-- [kup-text-input](../kup-text-input)
-- [kup-progress-bar](../kup-progress-bar)
-- [kup-combo](../kup-combo)
-- [kup-paginator](../kup-paginator)
+- [kup-badge](..\kup-badge)
+- [kup-image](..\kup-image)
+- [kup-button](..\kup-button)
+- [kup-checkbox](..\kup-checkbox)
+- [kup-radio](..\kup-radio)
+- [kup-text-input](..\kup-text-input)
+- [kup-progress-bar](..\kup-progress-bar)
+- [kup-combo](..\kup-combo)
+- [kup-paginator](..\kup-paginator)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-btn/readme.md
+++ b/packages/ketchup/src/components/kup-btn/readme.md
@@ -19,7 +19,7 @@
 
 ### Depends on
 
-- [kup-button](../kup-button)
+- [kup-button](..\kup-button)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-button/readme.md
+++ b/packages/ketchup/src/components/kup-button/readme.md
@@ -63,12 +63,12 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-btn](../kup-btn)
- - [kup-calendar](../kup-calendar)
- - [kup-data-table](../kup-data-table)
- - [kup-fld](../kup-fld)
- - [kup-html](../kup-html)
+ - [kup-box](..\kup-box)
+ - [kup-btn](..\kup-btn)
+ - [kup-calendar](..\kup-calendar)
+ - [kup-data-table](..\kup-data-table)
+ - [kup-fld](..\kup-fld)
+ - [kup-html](..\kup-html)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-calendar/readme.md
+++ b/packages/ketchup/src/components/kup-calendar/readme.md
@@ -51,7 +51,7 @@
 
 ### Depends on
 
-- [kup-button](../kup-button)
+- [kup-button](..\kup-button)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-checkbox/readme.md
+++ b/packages/ketchup/src/components/kup-checkbox/readme.md
@@ -43,9 +43,9 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-data-table](../kup-data-table)
- - [kup-tree](../kup-tree)
+ - [kup-box](..\kup-box)
+ - [kup-data-table](..\kup-data-table)
+ - [kup-tree](..\kup-tree)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-chip/readme.md
+++ b/packages/ketchup/src/components/kup-chip/readme.md
@@ -37,7 +37,7 @@
 
 ### Used by
 
- - [kup-data-table](../kup-data-table)
+ - [kup-data-table](..\kup-data-table)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-combo/readme.md
+++ b/packages/ketchup/src/components/kup-combo/readme.md
@@ -76,13 +76,13 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-paginator](../kup-paginator)
+ - [kup-box](..\kup-box)
+ - [kup-paginator](..\kup-paginator)
 
 ### Depends on
 
-- [kup-text-input](../kup-text-input)
-- [kup-portal](../kup-portal)
+- [kup-text-input](..\kup-text-input)
+- [kup-portal](..\kup-portal)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -143,15 +143,15 @@ Type: `Promise<Column[]>`
 
 ### Depends on
 
-- [kup-text-input](../kup-text-input)
-- [kup-checkbox](../kup-checkbox)
-- [kup-button](../kup-button)
-- [kup-graphic-cell](../kup-graphic-cell)
-- [kup-radio-element](../kup-radio-element)
-- [kup-tooltip](../kup-tooltip)
-- [kup-paginator](../kup-paginator)
-- [kup-chip](../kup-chip)
-- [kup-progress-bar](../kup-progress-bar)
+- [kup-text-input](..\kup-text-input)
+- [kup-checkbox](..\kup-checkbox)
+- [kup-button](..\kup-button)
+- [kup-graphic-cell](..\kup-graphic-cell)
+- [kup-radio-element](..\kup-radio-element)
+- [kup-tooltip](..\kup-tooltip)
+- [kup-paginator](..\kup-paginator)
+- [kup-chip](..\kup-chip)
+- [kup-progress-bar](..\kup-progress-bar)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-fld/readme.md
+++ b/packages/ketchup/src/components/kup-fld/readme.md
@@ -45,7 +45,7 @@ Type: `Promise<string | object>`
 
 ### Depends on
 
-- [kup-button](../kup-button)
+- [kup-button](..\kup-button)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-graphic-cell/readme.md
+++ b/packages/ketchup/src/components/kup-graphic-cell/readme.md
@@ -18,8 +18,8 @@
 
 ### Used by
 
- - [kup-data-table](../kup-data-table)
- - [kup-tree](../kup-tree)
+ - [kup-data-table](..\kup-data-table)
+ - [kup-tree](..\kup-tree)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-html/readme.md
+++ b/packages/ketchup/src/components/kup-html/readme.md
@@ -34,7 +34,7 @@
 
 ### Depends on
 
-- [kup-button](../kup-button)
+- [kup-button](..\kup-button)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-image/readme.md
+++ b/packages/ketchup/src/components/kup-image/readme.md
@@ -20,11 +20,11 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
+ - [kup-box](..\kup-box)
 
 ### Depends on
 
-- [kup-badge](../kup-badge)
+- [kup-badge](..\kup-badge)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-paginator/readme.md
+++ b/packages/ketchup/src/components/kup-paginator/readme.md
@@ -39,12 +39,12 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-data-table](../kup-data-table)
+ - [kup-box](..\kup-box)
+ - [kup-data-table](..\kup-data-table)
 
 ### Depends on
 
-- [kup-combo](../kup-combo)
+- [kup-combo](..\kup-combo)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-portal-instance/readme.md
+++ b/packages/ketchup/src/components/kup-portal-instance/readme.md
@@ -19,7 +19,7 @@
 
 ### Used by
 
- - [kup-portal](../kup-portal)
+ - [kup-portal](..\kup-portal)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-portal/readme.md
+++ b/packages/ketchup/src/components/kup-portal/readme.md
@@ -123,11 +123,11 @@ Type: `Promise<HTMLElement>`
 
 ### Used by
 
- - [kup-combo](../kup-combo)
+ - [kup-combo](..\kup-combo)
 
 ### Depends on
 
-- [kup-portal-instance](../kup-portal-instance)
+- [kup-portal-instance](..\kup-portal-instance)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-progress-bar/readme.md
+++ b/packages/ketchup/src/components/kup-progress-bar/readme.md
@@ -29,8 +29,8 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-data-table](../kup-data-table)
+ - [kup-box](..\kup-box)
+ - [kup-data-table](..\kup-data-table)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-radio-element/readme.md
+++ b/packages/ketchup/src/components/kup-radio-element/readme.md
@@ -29,7 +29,7 @@
 
 ### Used by
 
- - [kup-data-table](../kup-data-table)
+ - [kup-data-table](..\kup-data-table)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-radio/readme.md
+++ b/packages/ketchup/src/components/kup-radio/readme.md
@@ -41,7 +41,7 @@
 
 ### Used by
 
- - [kup-box](../kup-box)
+ - [kup-box](..\kup-box)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-text-input/readme.md
+++ b/packages/ketchup/src/components/kup-text-input/readme.md
@@ -62,9 +62,9 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [kup-box](../kup-box)
- - [kup-combo](../kup-combo)
- - [kup-data-table](../kup-data-table)
+ - [kup-box](..\kup-box)
+ - [kup-combo](..\kup-combo)
+ - [kup-data-table](..\kup-data-table)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-tooltip/readme.md
+++ b/packages/ketchup/src/components/kup-tooltip/readme.md
@@ -26,7 +26,7 @@
 
 ### Used by
 
- - [kup-data-table](../kup-data-table)
+ - [kup-data-table](..\kup-data-table)
 
 ### Graph
 ```mermaid

--- a/packages/ketchup/src/components/kup-tree/readme.md
+++ b/packages/ketchup/src/components/kup-tree/readme.md
@@ -106,8 +106,8 @@ open or close the TreeNodes.
 
 ### Depends on
 
-- [kup-checkbox](../kup-checkbox)
-- [kup-graphic-cell](../kup-graphic-cell)
+- [kup-checkbox](..\kup-checkbox)
+- [kup-graphic-cell](..\kup-graphic-cell)
 
 ### Graph
 ```mermaid


### PR DESCRIPTION
Applied to `kup-box`:
- ` .with-padding`, sets some padding/margins between box elements.

Applied to `.box-section`:
- `.left-aligned`, aligns content to the left;
- `.center-aligned`, aligns content to the center;
- `.right-aligned`, aligns content to the right.