### PR TITLE
Info in comments

### DIFF
--- a/packages/ketchup-showcase/public/showcase.css
+++ b/packages/ketchup-showcase/public/showcase.css
@@ -500,6 +500,12 @@ table.instruction-table th {
   bottom: 0;
 }
 
+#copy-html {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
 #sample-comp {
   width: 20%;
   display: inline-flex;

--- a/packages/ketchup-showcase/public/showcase.css
+++ b/packages/ketchup-showcase/public/showcase.css
@@ -495,12 +495,21 @@ table.instruction-table th {
   box-shadow: 0px 0px 7.5px 0px rgba(128, 128, 128, 0.5);
 }
 
+#view-swapper {
+  position: absolute;
+  bottom: 0;
+}
+
 #sample-comp {
   width: 20%;
   display: inline-flex;
   height: 100%;
   position: relative;
   overflow: auto;
+}
+
+#sample-comp.bigger {
+  width: 80%;
 }
 
 #sample-comp-wrapper {
@@ -512,6 +521,10 @@ table.instruction-table th {
   width: 80%;
   height: 100%;
   position: relative;
+}
+
+#sample-specs.smaller {
+  width: 20%;
 }
 
 #sample-specs wup-tab-bar {

--- a/packages/ketchup-showcase/public/showcase.css
+++ b/packages/ketchup-showcase/public/showcase.css
@@ -497,7 +497,6 @@ table.instruction-table th {
 
 #sample-comp {
   width: 20%;
-  min-width: 200px;
   display: inline-flex;
   height: 100%;
   position: relative;
@@ -511,7 +510,6 @@ table.instruction-table th {
 
 #sample-specs {
   width: 80%;
-  min-width: 200px;
   height: 100%;
   position: relative;
 }

--- a/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
+++ b/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
@@ -35,11 +35,11 @@
                 <td class="prevent-cr">
                   <span class="code-word">text</span>
                 </td>
-                <td
-                  >The button's text. If no value is specified, the button will
+                <td>
+                  The button's text. If no value is specified, the button will
                   render as an icon button, in this variant specifying an icon
-                  is mandatory.</td
-                >
+                  is mandatory.
+                </td>
                 <td class="prevent-cr">
                   <span class="code-word">string</span>
                 </td>
@@ -153,9 +153,10 @@
                 <td class="prevent-cr">
                   <span class="code-word">trailingicon</span>
                 </td>
-                <td>
-                  The button will display its associated icon after the text.
-                </td>
+                <td
+                  >The button will display its associated icon after the
+                  text.</td
+                >
                 <td class="prevent-cr">
                   <span class="code-word">boolean</span>
                 </td>
@@ -194,10 +195,10 @@
                 <td class="prevent-cr">
                   <span class="code-word">checked</span>
                 </td>
-                <td
-                  >Icon button variant only. The toggable icon button state will
-                  be initialized to ON.</td
-                >
+                <td>
+                  Icon button variant only. The toggable icon button state will
+                  be initialized to ON.
+                </td>
                 <td class="prevent-cr">
                   <span class="code-word">boolean</span>
                 </td>
@@ -286,9 +287,12 @@
             <div class="code-word"></div>
           </div>
           <div class="sample-section" style="display: none;">
-            <div class="code-word"
-              >This component does not require a JSON to work.</div
-            >
+            <wup-text-field
+              fullwidth
+              textarea
+              disabled
+              initialvalue="This component does not require a JSON to work."
+            ></wup-text-field>
           </div>
         </div>
       </div>

--- a/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
+++ b/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
@@ -13,6 +13,13 @@
             text="Demo"
           ></wup-button>
         </div>
+        <wup-button
+          @kupButtonClick="swapView"
+          id="view-swapper"
+          toggable
+          icon="fullscreen_exit"
+          iconoff="fullscreen"
+        ></wup-button>
       </div>
       <div id="sample-specs">
         <wup-tab-bar
@@ -212,6 +219,30 @@
                   ></wup-switch>
                 </td>
               </tr>
+              <tr>
+                <td class="prevent-cr">
+                  <span class="code-word">iconoff</span>
+                </td>
+                <td>
+                  Toggable icon button variant only. By default, the off state
+                  will be displayed as an outlined version of the icon prop. By
+                  setting this prop with a Material Design icon, the off state
+                  will show this icon instead.
+                </td>
+                <td class="prevent-cr">
+                  <span class="code-word">string</span>
+                </td>
+                <td class="prevent-cr">
+                  <span class="code-word">null</span>
+                </td>
+                <td class="text-cell">
+                  <wup-text-field
+                    icon="edit"
+                    id="iconoff"
+                    @kupTextFieldInput="updateDemoField"
+                  ></wup-text-field>
+                </td>
+              </tr>
             </tbody>
           </table>
           <table
@@ -319,6 +350,15 @@
 export default {
   name: 'ButtonBasic',
   methods: {
+    swapView(e) {
+      if (e.detail.value === 'on') {
+        document.querySelector('#sample-comp').classList.add('bigger');
+        document.querySelector('#sample-specs').classList.add('smaller');
+      } else {
+        document.querySelector('#sample-comp').classList.remove('bigger');
+        document.querySelector('#sample-specs').classList.remove('smaller');
+      }
+    },
     logClick(e) {
       var d = new Date();
       document.querySelector('#onclick').innerText =

--- a/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
+++ b/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
@@ -19,6 +19,7 @@
           toggable
           icon="fullscreen_exit"
           iconoff="fullscreen"
+          title="Increase/decrease demo size"
         ></wup-button>
       </div>
       <div id="sample-specs">

--- a/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
+++ b/packages/ketchup-showcase/src/views/basic/button/examples/ButtonBasic.vue
@@ -316,7 +316,13 @@
             </tbody>
           </table>
           <div class="sample-section" style="display: none;">
-            <div class="code-word"></div>
+            <div class="code-word sample-html"></div>
+            <wup-button
+              @kupButtonClick="copyHtml"
+              id="copy-html"
+              icon="file_copy"
+              title="Copy HTML markup"
+            ></wup-button>
           </div>
           <div class="sample-section" style="display: none;">
             <wup-text-field
@@ -351,6 +357,10 @@
 export default {
   name: 'ButtonBasic',
   methods: {
+    copyHtml(e) {
+      let text = document.querySelector('.code-word.sample-html').innerText;
+      navigator.clipboard.writeText(text);
+    },
     swapView(e) {
       if (e.detail.value === 'on') {
         document.querySelector('#sample-comp').classList.add('bigger');
@@ -442,6 +452,11 @@ export default {
             ).innerText = tabCollection[i]
               .querySelector('.code-word')
               .innerText.replace('class="hydrated"', '');
+            tabCollection[i].querySelector(
+              '.code-word'
+            ).innerText = tabCollection[i]
+              .querySelector('.code-word')
+              .innerText.replace(/=""/g, '');
           }
         } else {
           tabCollection[i].setAttribute('style', 'display: none;');

--- a/packages/ketchup-showcase/src/views/basic/button/examples/ButtonIconVariant.vue
+++ b/packages/ketchup-showcase/src/views/basic/button/examples/ButtonIconVariant.vue
@@ -21,7 +21,11 @@
         >The icon button can also work as a toggler switching between ON and
         OFF. To use it in this way, you need to specify the attribute
         <span class="code-word">toggable</span>. To render an icon toggled ON,
-        use the attribute <span class="code-word">checked</span>.</p
+        use the attribute <span class="code-word">checked</span>. By default,
+        the off state will show an outlined version of the
+        <span class="code-word">icon</span>. You can change this by setting a
+        Material Design icon value in the prop
+        <span class="code-word">iconoff</span>.</p
       ><div class="demo-container">
         <div class="kup-container">
           <wup-button toggable icon="favorite"></wup-button>

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -914,6 +914,10 @@ export namespace Components {
     */
     'icon': string;
     /**
+    * Defaults at null. When set, the icon button off state will show this icon. Otherwise, an outlined version of the icon prop will be displayed.
+    */
+    'iconoff': string;
+    /**
     * Defaults at false. When set to true, the button will be rendered with rounded edges.
     */
     'rounded': boolean;
@@ -2429,6 +2433,10 @@ declare namespace LocalJSX {
     * Defaults at null. When set, the button will show this icon.
     */
     'icon'?: string;
+    /**
+    * Defaults at null. When set, the icon button off state will show this icon. Otherwise, an outlined version of the icon prop will be displayed.
+    */
+    'iconoff'?: string;
     'onKupButtonBlur'?: (event: CustomEvent<{
       value: any;
     }>) => void;

--- a/packages/ketchup/src/components/wup-button/readme.md
+++ b/packages/ketchup/src/components/wup-button/readme.md
@@ -7,17 +7,18 @@
 
 ## Properties
 
-| Property       | Attribute      | Description                                                                              | Type      | Default |
-| -------------- | -------------- | ---------------------------------------------------------------------------------------- | --------- | ------- |
-| `checked`      | `checked`      | Defaults at false. When set to true, the icon button state will be on.                   | `boolean` | `false` |
-| `disabled`     | `disabled`     | Defaults at false. When set to true, the component is disabled.                          | `boolean` | `false` |
-| `flat`         | `flat`         | Defaults at false. When set to true, the button will be rendered flat.                   | `boolean` | `false` |
-| `icon`         | `icon`         | Defaults at null. When set, the button will show this icon.                              | `string`  | `null`  |
-| `rounded`      | `rounded`      | Defaults at false. When set to true, the button will be rendered with rounded edges.     | `boolean` | `false` |
-| `text`         | `text`         | Defaults at null. When set, the button will show this text.                              | `string`  | `null`  |
-| `toggable`     | `toggable`     | Defaults at false. When set to true, the icon button will be toggable on/off.            | `boolean` | `false` |
-| `trailingicon` | `trailingicon` | Defaults at null. When set, the icon will be shown after the text.                       | `boolean` | `false` |
-| `transparent`  | `transparent`  | Defaults at false. When set to true, the button will be rendered with a colored outline. | `boolean` | `false` |
+| Property       | Attribute      | Description                                                                                                                                   | Type      | Default |
+| -------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `checked`      | `checked`      | Defaults at false. When set to true, the icon button state will be on.                                                                        | `boolean` | `false` |
+| `disabled`     | `disabled`     | Defaults at false. When set to true, the component is disabled.                                                                               | `boolean` | `false` |
+| `flat`         | `flat`         | Defaults at false. When set to true, the button will be rendered flat.                                                                        | `boolean` | `false` |
+| `icon`         | `icon`         | Defaults at null. When set, the button will show this icon.                                                                                   | `string`  | `null`  |
+| `iconoff`      | `iconoff`      | Defaults at null. When set, the icon button off state will show this icon. Otherwise, an outlined version of the icon prop will be displayed. | `string`  | `null`  |
+| `rounded`      | `rounded`      | Defaults at false. When set to true, the button will be rendered with rounded edges.                                                          | `boolean` | `false` |
+| `text`         | `text`         | Defaults at null. When set, the button will show this text.                                                                                   | `string`  | `null`  |
+| `toggable`     | `toggable`     | Defaults at false. When set to true, the icon button will be toggable on/off.                                                                 | `boolean` | `false` |
+| `trailingicon` | `trailingicon` | Defaults at null. When set, the icon will be shown after the text.                                                                            | `boolean` | `false` |
+| `transparent`  | `transparent`  | Defaults at false. When set to true, the button will be rendered with a colored outline.                                                      | `boolean` | `false` |
 
 
 ## Events

--- a/packages/ketchup/src/components/wup-button/wup-button.tsx
+++ b/packages/ketchup/src/components/wup-button/wup-button.tsx
@@ -48,6 +48,10 @@ export class WupButton {
      */
     @Prop() icon: string = null;
     /**
+     * Defaults at null. When set, the icon button off state will show this icon. Otherwise, an outlined version of the icon prop will be displayed.
+     */
+    @Prop() iconoff: string = null;
+    /**
      * Defaults at null. When set, the icon will be shown after the text.
      */
     @Prop() trailingicon: boolean = false;
@@ -151,7 +155,7 @@ export class WupButton {
 
     //---- Lifecycle hooks ----
 
-    componentWillLoad() {
+    componentWillRender() {
         if (this.text === null && this.icon !== null) {
             if (this.checked) {
                 this.value = 'on';
@@ -267,7 +271,14 @@ export class WupButton {
                 if (this.checked) {
                     widgetClass += ' mdc-icon-button--on';
                 }
-                let iconOff = this.icon + '_border';
+                let iconOff: string;
+
+                if (this.iconoff) {
+                    iconOff = this.iconoff;
+                } else {
+                    iconOff = this.icon + '_border';
+                }
+
                 leadingEl = (
                     <i
                         class="material-icons mdc-icon-button__icon"

--- a/packages/ketchup/src/components/wup-checkbox/wup-checkbox.tsx
+++ b/packages/ketchup/src/components/wup-checkbox/wup-checkbox.tsx
@@ -131,7 +131,7 @@ export class WupCheckbox {
 
     //---- Lifecycle hooks ----
 
-    componentWillLoad() {
+    componentWillRender() {
         if (this.checked) {
             this.value = 'on';
         } else {

--- a/packages/ketchup/src/components/wup-switch/wup-switch.tsx
+++ b/packages/ketchup/src/components/wup-switch/wup-switch.tsx
@@ -127,7 +127,7 @@ export class WupSwitch {
 
     //---- Lifecycle hooks ----
 
-    componentWillLoad() {
+    componentWillRender() {
         if (this.checked) {
             this.value = 'on';
         } else {

--- a/packages/ketchup/src/components/wup-tab-bar/wup-tab-bar.scss
+++ b/packages/ketchup/src/components/wup-tab-bar/wup-tab-bar.scss
@@ -7,10 +7,14 @@
   display: var(--kup-display-mode);
 
   #kup-component {
-    .mdc-tab-bar {
+    & .mdc-tab-bar {
       @include mdc-tab-bar-density(-3);
       @include mdc-tab-text-label-color(var(--kup-main-color));
       @include mdc-tab-icon-color(var(--kup-main-color));
+
+      & .mdc-tab-scroller__scroll-area--scroll {
+        overflow: auto;
+      }
 
       & button {
         font-family: var(--kup-font-family);

--- a/packages/ketchup/src/components/wup-text-field/wup-text-field.scss
+++ b/packages/ketchup/src/components/wup-text-field/wup-text-field.scss
@@ -72,6 +72,11 @@
       &.mdc-text-field--disabled {
         color: var(--kup-disabled-text-color);
         background: var(--kup-disabled-background-color);
+
+        & .mdc-text-field__input {
+          color: var(--kup-disabled-text-color);
+          background: var(--kup-disabled-background-color);
+        }
       }
     }
 

--- a/packages/ketchup/src/index.html
+++ b/packages/ketchup/src/index.html
@@ -266,6 +266,7 @@
         <wup-button icon="favorite"></wup-button>
         <wup-button disabled icon="favorite"></wup-button>
         <wup-button toggable icon="favorite"></wup-button>
+        <wup-button toggable icon="menu" iconoff="favorite"></wup-button>
         <wup-button toggable checked icon="favorite"></wup-button>
         <wup-button disabled icon="favorite"></wup-button>
         <wup-button text="Flat" flat></wup-button>


### PR DESCRIPTION
- Fixed issue on Tab Bar displaying scroll area on Firefox and Edge (Material Design problem)
- Added textarea to JSON section of demo panel and improved look.
- Added new prop to button, iconoff. Changed value initialization in events for basic components.
- Added icon button in demo panel to switch display mode.
- Added title to demo panel icon button.
- Added copy to HTML demo panel. Updated button page with new prop.
- Fixed disabled color in textarea.