### PR TITLE
google charts - bar charts - stacked option

### DIFF
--- a/packages/ketchup/src/components/kup-chart/kup-chart-declarations.ts
+++ b/packages/ketchup/src/components/kup-chart/kup-chart-declarations.ts
@@ -14,6 +14,7 @@ export enum ChartType {
     Sankey = 'Sankey',
     Scatter = 'Scatter',
     Unk = 'Unk',
+    ColumnChart = 'ColumnChart',
     Vbar = 'Vbar',
 }
 

--- a/packages/ketchup/src/components/kup-chart/kup-chart.tsx
+++ b/packages/ketchup/src/components/kup-chart/kup-chart.tsx
@@ -234,7 +234,9 @@ export class KupChart {
 
         if (
             this.stacked &&
-            (ChartType.Hbar === this.getMainChartType() ||
+            (ChartType.ColumnChart === this.getMainChartType() ||
+                ChartType.Unk === this.getMainChartType() ||
+                ChartType.Hbar === this.getMainChartType() ||
                 ChartType.Vbar === this.getMainChartType())
         ) {
             opts.isStacked = true;


### PR DESCRIPTION
google charts - bar charts - stacked option: if not set chart type from scheda (it means will be rendered a VBar chart) managed attribute stacked, like already done for HBar and VBar charts; chart type: ColumnChart