### PR TITLE
Tooltip tests

### DIFF
--- a/packages/ketchup/src/assets/tooltip.js
+++ b/packages/ketchup/src/assets/tooltip.js
@@ -1,0 +1,57 @@
+function setTooltip(id) {
+    const tooltip = document.getElementById('globaltooltip');
+    let elem;
+    if (id) {
+        elem = document.getElementById(id);
+    }
+    let related; 
+    if (elem) {
+        related = {
+            element: elem,
+            object: "Sono il quadrato "+ elem.id
+        }    
+    }
+    tooltip.relatedObject = related;
+}
+
+function onMouseOver(ev) {
+    if (ev.target.id) {
+        setTooltip(ev.target.id)
+    }
+}
+
+function onMouseLeave() {
+    setTooltip()    
+}
+
+function loadData(event) {
+    this.labelText = '';
+    let data = {
+          title: event.detail.object,
+          content: {
+            info1: {
+              label: 'Author',
+              value: 'Lana del Rey',
+            },
+            info2: {
+              label: 'Year',
+              value: 2012,
+            },
+          },
+        };
+        
+    event.target.data = data;
+}
+
+const rosso = document.getElementById('rosso');
+const verde = document.getElementById('verde');
+const blu = document.getElementById('blu');
+const t = document.getElementById('globaltooltip');
+
+rosso.addEventListener("mouseover", onMouseOver);
+verde.addEventListener("mouseover", onMouseOver);
+blu.addEventListener("mouseover", onMouseOver);
+rosso.addEventListener("mouseleave", onMouseLeave);
+verde.addEventListener("mouseleave", onMouseLeave);
+blu.addEventListener("mouseleave", onMouseLeave);
+t.addEventListener("kupTooltipLoadData", loadData);

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -18,6 +18,7 @@ import { CrudCallBackOnFormEventResult, CrudConfig, CrudRecord, CrudRecordsChang
 import { FormActionEventDetail, FormActions, FormCells, FormConfig, FormFieldEventDetail, FormFields, FormMessage, FormSection } from "./components/kup-form/kup-form-declarations";
 import { SearchFilterSubmittedEventDetail, SearchSelectionUpdatedEventDetail } from "./components/kup-search/kup-search-declarations";
 import { KupStore } from "./components/kup-state/kup-store";
+import { KupTooltip } from "./components/kup-tooltip/kup-tooltip";
 import { KupFldChangeEvent, KupFldSubmitEvent } from "./components/kup-field/kup-field-declarations";
 import { ComponentGridElement } from "./components/kup-grid/kup-grid-declarations";
 import { KupBadge } from "./components/kup-badge/kup-badge";
@@ -2430,7 +2431,7 @@ declare namespace LocalJSX {
          */
         "onKupDetailRequest"?: (event: CustomEvent<{
         cell: Cell;
-        tooltip: EventTarget;
+        tooltip: KupTooltip;
     }>) => void;
         "onKupLoadMoreClicked"?: (event: CustomEvent<{
         loadItems: number;
@@ -2440,7 +2441,7 @@ declare namespace LocalJSX {
          */
         "onKupLoadRequest"?: (event: CustomEvent<{
         cell: Cell;
-        tooltip: EventTarget;
+        tooltip: KupTooltip;
     }>) => void;
         /**
           * When cell option is clicked
@@ -3370,8 +3371,8 @@ declare namespace LocalJSX {
         "onKupDefaultOptionClicked"?: (event: CustomEvent<{
         obj: TooltipObject;
     }>) => void;
-        "onKupTooltipLoadData"?: (event: CustomEvent<any>) => void;
-        "onKupTooltipLoadDetail"?: (event: CustomEvent<any>) => void;
+        "onKupTooltipLoadData"?: (event: CustomEvent<{ relatedObject: TooltipRelatedObject }>) => void;
+        "onKupTooltipLoadDetail"?: (event: CustomEvent<{ relatedObject: TooltipRelatedObject }>) => void;
         /**
           * Container element for tooltip
          */

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -27,7 +27,7 @@ import { PaginatorMode } from "./components/kup-paginator/kup-paginator-declarat
 import { KupQlikGrid, QlikServer } from "./components/kup-qlik/kup-qlik-declarations";
 import { ComponentRadioElement } from "./components/kup-radio/kup-radio-declarations";
 import { ComponentTabBarElement } from "./components/kup-tab-bar/kup-tab-bar-declarations";
-import { TooltipAction, TooltipData, TooltipDetailData, TooltipObject } from "./components/kup-tooltip/kup-tooltip-declarations";
+import { TooltipAction, TooltipData, TooltipDetailData, TooltipObject, TooltipRelatedObject } from "./components/kup-tooltip/kup-tooltip-declarations";
 import { TreeNode, TreeNodePath } from "./components/kup-tree/kup-tree-declarations";
 import { UploadProps } from "./components/kup-upload/kup-upload-declarations";
 export namespace Components {
@@ -1306,6 +1306,10 @@ export namespace Components {
           * Timeout for tooltip
          */
         "loadTimeout": number;
+        /**
+          * Container element for tooltip
+         */
+        "relatedObject": TooltipRelatedObject;
     }
     interface KupTree {
         /**
@@ -3360,6 +3364,10 @@ declare namespace LocalJSX {
     }>) => void;
         "onKupTooltipLoadData"?: (event: CustomEvent<any>) => void;
         "onKupTooltipLoadDetail"?: (event: CustomEvent<any>) => void;
+        /**
+          * Container element for tooltip
+         */
+        "relatedObject"?: TooltipRelatedObject;
     }
     interface KupTree {
         /**

--- a/packages/ketchup/src/components/kup-crud/readme.md
+++ b/packages/ketchup/src/components/kup-crud/readme.md
@@ -95,16 +95,16 @@ graph TD;
   kup-data-table --> kup-button
   kup-data-table --> kup-image
   kup-data-table --> kup-text-field
+  kup-data-table --> kup-tooltip
   kup-data-table --> kup-lazy
   kup-data-table --> kup-progress-bar
   kup-data-table --> kup-radio
-  kup-data-table --> kup-tooltip
   kup-data-table --> kup-paginator
   kup-data-table --> kup-combobox
   kup-data-table --> kup-chip
-  kup-progress-bar --> kup-image
   kup-tooltip --> kup-button
   kup-tooltip --> kup-image
+  kup-progress-bar --> kup-image
   kup-paginator --> kup-button
   kup-paginator --> kup-combobox
   kup-chip --> kup-image

--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -54,6 +54,7 @@ If the `sticky` element would be hidden by the scroll, after having specified a 
 | `loadMoreMode`              | `load-more-mode`               | Establish the modality of how many new records will be downloaded.  This property is regulated also by loadMoreStep.                                                                                                           | `LoadMoreMode.CONSTANT \| LoadMoreMode.CONSTANT_INCREMENT \| LoadMoreMode.PROGRESSIVE_THRESHOLD` | `LoadMoreMode.PROGRESSIVE_THRESHOLD` |
 | `loadMoreStep`              | `load-more-step`               | The number of records which will be requested to be downloaded when clicking on the load more button.  This property is regulated also by loadMoreMode.                                                                        | `number`                                                                                         | `60`                                 |
 | `multiSelection`            | `multi-selection`              | When set to true enables rows multi selection.                                                                                                                                                                                 | `boolean`                                                                                        | `false`                              |
+| `pageSelected`              | `page-selected`                | Current selected page set on component load                                                                                                                                                                                    | `number`                                                                                         | `-1`                                 |
 | `paginatorPos`              | `paginator-pos`                | Sets the position of the paginator. Available positions: top, bottom or both.                                                                                                                                                  | `PaginatorPos.BOTH \| PaginatorPos.BOTTOM \| PaginatorPos.TOP`                                   | `PaginatorPos.TOP`                   |
 | `rowActions`                | --                             | Sets the actions of the rows.                                                                                                                                                                                                  | `RowAction[]`                                                                                    | `undefined`                          |
 | `rowsPerPage`               | `rows-per-page`                | Sets the number of rows per page to display.                                                                                                                                                                                   | `number`                                                                                         | `10`                                 |
@@ -82,9 +83,9 @@ If the `sticky` element would be hidden by the scroll, after having specified a 
 | `kupAutoRowSelect`         | When a row is auto selected via selectRow prop | `CustomEvent<{ selectedRow: Row; }>`                                                                          |
 | `kupCellButtonClicked`     |                                                | `CustomEvent<KupDataTableCellButtonClick>`                                                                    |
 | `kupDataTableSortedColumn` |                                                | `CustomEvent<KupDataTableSortedColumnIndexes>`                                                                |
-| `kupDetailRequest`         | When a tooltip request detail data             | `CustomEvent<{ cell: Cell; tooltip: EventTarget; }>`                                                          |
+| `kupDetailRequest`         | When a tooltip request detail data             | `CustomEvent<{ cell: Cell; tooltip: KupTooltip; }>`                                                           |
 | `kupLoadMoreClicked`       |                                                | `CustomEvent<{ loadItems: number; }>`                                                                         |
-| `kupLoadRequest`           | When a tooltip request initial data            | `CustomEvent<{ cell: Cell; tooltip: EventTarget; }>`                                                          |
+| `kupLoadRequest`           | When a tooltip request initial data            | `CustomEvent<{ cell: Cell; tooltip: KupTooltip; }>`                                                           |
 | `kupOptionClicked`         | When cell option is clicked                    | `CustomEvent<{ column: string; row: Row; }>`                                                                  |
 | `kupRowActionClicked`      | When a row action is clicked                   | `CustomEvent<{ type: "default" \| "variable" \| "expander"; row: Row; action?: RowAction; index?: number; }>` |
 | `kupRowSelected`           | When a row is selected                         | `CustomEvent<{ selectedRows: Row[]; clickedColumn: string; }>`                                                |
@@ -159,10 +160,10 @@ Type: `Promise<{ groups: GroupObject[]; filters: GenericFilter; data: TableData;
 - [kup-button](../kup-button)
 - [kup-image](../kup-image)
 - [kup-text-field](../kup-text-field)
+- [kup-tooltip](../kup-tooltip)
 - [kup-lazy](../kup-lazy)
 - [kup-progress-bar](../kup-progress-bar)
 - [kup-radio](../kup-radio)
-- [kup-tooltip](../kup-tooltip)
 - [kup-paginator](../kup-paginator)
 - [kup-combobox](../kup-combobox)
 - [kup-chip](../kup-chip)
@@ -174,10 +175,10 @@ graph TD;
   kup-data-table --> kup-button
   kup-data-table --> kup-image
   kup-data-table --> kup-text-field
+  kup-data-table --> kup-tooltip
   kup-data-table --> kup-lazy
   kup-data-table --> kup-progress-bar
   kup-data-table --> kup-radio
-  kup-data-table --> kup-tooltip
   kup-data-table --> kup-paginator
   kup-data-table --> kup-combobox
   kup-data-table --> kup-chip
@@ -186,9 +187,9 @@ graph TD;
   kup-image --> kup-badge
   kup-badge --> kup-image
   kup-text-field --> kup-image
-  kup-progress-bar --> kup-image
   kup-tooltip --> kup-button
   kup-tooltip --> kup-image
+  kup-progress-bar --> kup-image
   kup-paginator --> kup-button
   kup-paginator --> kup-combobox
   kup-combobox --> kup-text-field

--- a/packages/ketchup/src/components/kup-form/readme.md
+++ b/packages/ketchup/src/components/kup-form/readme.md
@@ -159,16 +159,16 @@ graph TD;
   kup-data-table --> kup-button
   kup-data-table --> kup-image
   kup-data-table --> kup-text-field
+  kup-data-table --> kup-tooltip
   kup-data-table --> kup-lazy
   kup-data-table --> kup-progress-bar
   kup-data-table --> kup-radio
-  kup-data-table --> kup-tooltip
   kup-data-table --> kup-paginator
   kup-data-table --> kup-combobox
   kup-data-table --> kup-chip
-  kup-progress-bar --> kup-image
   kup-tooltip --> kup-button
   kup-tooltip --> kup-image
+  kup-progress-bar --> kup-image
   kup-paginator --> kup-button
   kup-paginator --> kup-combobox
   kup-chip --> kup-image

--- a/packages/ketchup/src/components/kup-search/readme.md
+++ b/packages/ketchup/src/components/kup-search/readme.md
@@ -55,16 +55,16 @@ graph TD;
   kup-data-table --> kup-button
   kup-data-table --> kup-image
   kup-data-table --> kup-text-field
+  kup-data-table --> kup-tooltip
   kup-data-table --> kup-lazy
   kup-data-table --> kup-progress-bar
   kup-data-table --> kup-radio
-  kup-data-table --> kup-tooltip
   kup-data-table --> kup-paginator
   kup-data-table --> kup-combobox
   kup-data-table --> kup-chip
-  kup-progress-bar --> kup-image
   kup-tooltip --> kup-button
   kup-tooltip --> kup-image
+  kup-progress-bar --> kup-image
   kup-paginator --> kup-button
   kup-paginator --> kup-combobox
   kup-combobox --> kup-text-field

--- a/packages/ketchup/src/components/kup-tooltip/kup-tooltip-declarations.ts
+++ b/packages/ketchup/src/components/kup-tooltip/kup-tooltip-declarations.ts
@@ -29,3 +29,8 @@ export interface TooltipAction {
 export interface TooltipDetailData extends DataTable {    
     actions?: {command: Array<TooltipAction>};
 }
+
+export interface TooltipRelatedObject {
+    element: HTMLElement;
+    object?: any;
+}

--- a/packages/ketchup/src/components/kup-tooltip/kup-tooltip-declarations.ts
+++ b/packages/ketchup/src/components/kup-tooltip/kup-tooltip-declarations.ts
@@ -1,12 +1,12 @@
-import { DataTable } from "../kup-data-table/kup-data-table-declarations";
-
+import { DataTable } from '../kup-data-table/kup-data-table-declarations';
 
 export interface TooltipObject {
-    t:String;
-    p:String;
-    k:String;
-    url:String;
+    t: String;
+    p: String;
+    k: String;
+    url: String;
 }
+
 export interface TooltipData {
     obj?: TooltipObject;
     image?: string;
@@ -20,14 +20,14 @@ export interface TooltipData {
 }
 
 export interface TooltipAction {
-    text: string;    
+    text: string;
     icon: string;
     exec: string;
     url: string;
 }
 
-export interface TooltipDetailData extends DataTable {    
-    actions?: {command: Array<TooltipAction>};
+export interface TooltipDetailData extends DataTable {
+    actions?: { command: Array<TooltipAction> };
 }
 
 export interface TooltipRelatedObject {

--- a/packages/ketchup/src/components/kup-tooltip/kup-tooltip.scss
+++ b/packages/ketchup/src/components/kup-tooltip/kup-tooltip.scss
@@ -18,6 +18,21 @@
   #wrapper {
     display: var(--tlt_display);
 
+    /*
+    position: absolute;
+
+    &.is-tooltip {
+      position: relative;
+    }
+
+    &.visible.dynamic-position-active {
+      display: block;
+      -webkit-animation: display-none-transition 0.5s both;
+      -webkit-animation-timing-function: cubic-bezier(0.67, -0.81, 0.89, 0.71);
+      animation: display-none-transition 0.5s both;
+      animation-timing-function: cubic-bezier(0.67, -0.81, 0.89, 0.71);
+    }*/
+
     #tooltip {
       position: fixed;
       background: var(--tlt_background);
@@ -133,14 +148,18 @@
 
 :host(.datatable-tooltip) {
   position: absolute;
-  height: 100%;
-  width: 100%;
+  /*height: 100%;
+  width: 100%;*/
+  height: 0;
+  width: 0;
   left: 0;
   top: 0;
   #wrapper {
     position: absolute;
-    height: 100%;
-    width: 100%;
+    /*height: 100%;
+    width: 100%;*/
+    height: 0;
+    width: 0;
     left: 0;
     top: 0;
   }

--- a/packages/ketchup/src/components/kup-tooltip/kup-tooltip.tsx
+++ b/packages/ketchup/src/components/kup-tooltip/kup-tooltip.tsx
@@ -13,6 +13,7 @@ import { Row } from '../kup-data-table/kup-data-table-declarations';
 import {
     TooltipData,
     TooltipDetailData,
+    TooltipRelatedObject,
     TooltipAction,
     TooltipObject,
 } from './kup-tooltip-declarations';
@@ -54,6 +55,12 @@ export class KupTooltip {
      */
     @Prop()
     loadTimeout: number = 1000;
+
+    /**
+     * Container element for tooltip
+     */
+    @Prop()
+    relatedObject: TooltipRelatedObject;
 
     @State()
     visible = false;
@@ -103,6 +110,16 @@ export class KupTooltip {
     kupDefaultOptionClicked: EventEmitter<{
         obj: TooltipObject;
     }>;
+
+    @Watch('relatedObject')
+    onElementChanged() {
+        if (this.relatedObject) {
+            this.visible = true;
+            this.kupTooltipLoadData.emit(this.relatedObject);
+        } else {
+            this.visible = false;
+        }
+    }
 
     @Watch('data')
     onDataChanged() {
@@ -335,8 +352,11 @@ export class KupTooltip {
     private positionRecalc() {
         // resetting position
         this.tooltipPosition = {};
-
-        const rect = this.wrapperEl.getBoundingClientRect();
+        let rect;
+        if (this.relatedObject) 
+            rect = this.relatedObject.element.getBoundingClientRect();
+        else
+            rect = this.wrapperEl.getBoundingClientRect();
         let threshold = this.hasDetailData ? 300 : 150;
 
         // vertical position

--- a/packages/ketchup/src/components/kup-tooltip/kup-tooltip.tsx
+++ b/packages/ketchup/src/components/kup-tooltip/kup-tooltip.tsx
@@ -18,6 +18,7 @@ import {
     TooltipObject,
 } from './kup-tooltip-declarations';
 import { logMessage } from '../../utils/debug-manager';
+//import { positionRecalc } from '../../utils/recalc-position';
 
 @Component({
     tag: 'kup-tooltip',
@@ -71,7 +72,7 @@ export class KupTooltip {
         cancelable: false,
         bubbles: true,
     })
-    kupTooltipLoadData: EventEmitter;
+    kupTooltipLoadData: EventEmitter<{ relatedObject: TooltipRelatedObject }>;
 
     @Event({
         eventName: 'kupTooltipLoadDetail',
@@ -79,7 +80,7 @@ export class KupTooltip {
         cancelable: false,
         bubbles: true,
     })
-    kupTooltipLoadDetail: EventEmitter;
+    kupTooltipLoadDetail: EventEmitter<{ relatedObject: TooltipRelatedObject }>;
 
     @Event({
         eventName: 'kupActionCommandClicked',
@@ -113,18 +114,17 @@ export class KupTooltip {
 
     @Watch('relatedObject')
     onElementChanged() {
-        if (this.relatedObject) {
-            this.visible = true;
-            this.kupTooltipLoadData.emit(this.relatedObject);
+        if (this.relatedObject != null) {
+            this.loadAll();
         } else {
-            this.visible = false;
+            this.resetAll();
         }
     }
 
     @Watch('data')
     onDataChanged() {
-        if (this.visible) {
-            this.positionRecalc();
+        if (this.visible == true) {
+            this.positionRecalc_();
             // loading detail
             this.loadDetailTimeout = setTimeout(
                 () => this.loadDetail(),
@@ -144,7 +144,7 @@ export class KupTooltip {
     private tooltipTimeout: NodeJS.Timeout;
     private loadDetailTimeout: NodeJS.Timeout;
     private mouseLeaveTimeout: NodeJS.Timeout;
-    private wrapperEl: HTMLSpanElement;
+    private wrapperEl: HTMLElement;
     private startTime: number = 0;
     private endTime: number = 0;
     private renderCount: number = 0;
@@ -165,16 +165,26 @@ export class KupTooltip {
     }
 
     private resetTimeouts() {
+        this.resetTooltipTimeout();
+        this.resetLoadDetailTimeout();
+        this.resetMouseLeaveTimeout();
+    }
+
+    private resetTooltipTimeout() {
         if (this.tooltipTimeout) {
             clearTimeout(this.tooltipTimeout);
             this.tooltipTimeout = null;
         }
+    }
 
+    private resetLoadDetailTimeout() {
         if (this.loadDetailTimeout) {
             clearTimeout(this.loadDetailTimeout);
             this.loadDetailTimeout = null;
         }
+    }
 
+    private resetMouseLeaveTimeout() {
         if (this.mouseLeaveTimeout) {
             clearTimeout(this.mouseLeaveTimeout);
             this.mouseLeaveTimeout = null;
@@ -182,8 +192,8 @@ export class KupTooltip {
     }
 
     private loadDetail() {
-        this.loadDetailTimeout = null;
-        this.kupTooltipLoadDetail.emit();
+        this.resetLoadDetailTimeout();
+        this.kupTooltipLoadDetail.emit({ relatedObject: this.relatedObject });
     }
 
     get rows(): Row[] {
@@ -233,22 +243,27 @@ export class KupTooltip {
     }
 
     // ---- Listeners ----
+    private loadAll() {
+        this.resetAll();
+        this.prepareLoadData();
+    }
+
+    private prepareLoadData() {
+        this.tooltipTimeout = setTimeout(() => {
+            this.visible = true;
+            this.kupTooltipLoadData.emit({
+                relatedObject: this.relatedObject,
+            });
+        }, this.loadTimeout);
+    }
+
     private onMouseOver() {
         // Cancello il mouseLeaveTimeout così se l'utente
         // esce e rientra rimanendo nell'intervallo di 500ms
         // il tip non si chiude
-        if (this.mouseLeaveTimeout) {
-            clearTimeout(this.mouseLeaveTimeout);
-            this.mouseLeaveTimeout = null;
-        }
+        this.resetMouseLeaveTimeout();
         if (!this.tooltipTimeout) {
-            this.tooltipTimeout = setTimeout(() => {
-                this.tooltipTimeout = null;
-
-                this.visible = true;
-
-                this.kupTooltipLoadData.emit();
-            }, this.loadTimeout);
+            this.prepareLoadData();
         }
     }
 
@@ -273,20 +288,33 @@ export class KupTooltip {
     }
 
     private onMouseLeave() {
+        /* per qualche motivo, se il tooltip è aperto all'in su rispetto al componente di riferimento, viene chiuso subito
+         se abilito la gestione del onmouseleave() ???? da riguardare
+        if (this.data == null) {
+            return;
+        }
+        if (this.detailData == null) {
+            return;
+        }
         // Se non sono presenti azioni si chiude immediatamente, altrimenti
         // lo chiudo dopo 500ms
         let timeout = this.hasActionsData() ? 500 : 0;
         this.mouseLeaveTimeout = setTimeout(() => {
-            // reset data
-            this.data = null;
-            this.detailData = null;
-
-            // reset visibility
-            this.visible = false;
-
-            // reset timeouts
-            this.resetTimeouts();
+            this.resetAll();
         }, timeout);
+        */
+    }
+
+    private resetAll() {
+        // reset data
+        this.data = null;
+        this.detailData = null;
+
+        // reset visibility
+        this.visible = false;
+
+        // reset timeouts
+        this.resetTimeouts();
     }
 
     // ---- Render methods ----
@@ -349,14 +377,41 @@ export class KupTooltip {
         return infos;
     }
 
-    private positionRecalc() {
+    private positionRecalc_() {
+        /*
+        if (this.visible == true) {
+            if (this.relatedObject != null) {
+                this.wrapperEl.classList.add('visible');
+                this.wrapperEl.classList.add('dynamic-position-active');
+                let offsetH = this.hasDetailData ? 300 : 150;
+                let offsetW = 350;
+                let margin = 3;
+                positionRecalc(
+                    this.wrapperEl,
+                    this.relatedObject.element,
+                    margin,
+                    offsetH,
+                    offsetW
+                );
+                this.tooltipPosition = {};
+                this.tooltipPosition.top = this.wrapperEl.style.top;
+                this.tooltipPosition.left = this.wrapperEl.style.left;
+                this.tooltipPosition.right = this.wrapperEl.style.right;
+                this.tooltipPosition.bottom = this.wrapperEl.style.bottom;
+                return;
+            }
+        }
+        this.wrapperEl.classList.remove('visible');
+        this.wrapperEl.classList.remove('dynamic-position-active');
+        */
         // resetting position
         this.tooltipPosition = {};
         let rect;
-        if (this.relatedObject) 
+        if (this.relatedObject != null) {
             rect = this.relatedObject.element.getBoundingClientRect();
-        else
+        } else {
             rect = this.wrapperEl.getBoundingClientRect();
+        }
         let threshold = this.hasDetailData ? 300 : 150;
 
         // vertical position
@@ -397,7 +452,6 @@ export class KupTooltip {
 
         let detailContent = null;
         let detailActions = null;
-        //console.log(this.detailData);
         if (this.hasDetailData()) {
             detailContent = this.rows.map((row) =>
                 row.cells['label'].value === '' ||
@@ -439,7 +493,6 @@ export class KupTooltip {
         const tooltipStyle = {
             ...this.tooltipPosition,
         };
-
         return (
             <div
                 id="tooltip"
@@ -487,15 +540,32 @@ export class KupTooltip {
     }
 
     render() {
+        const tooltipStyle = {
+            ...this.tooltipPosition,
+        };
+
+        const classObj: Record<string, boolean> = {
+            visible: this.visible && this.data ? true : false,
+        };
+
+        /*
+        hidden={!this.visible || !this.data}
+                style={tooltipStyle}
+                class={classObj}
+                */
         return (
             <div
                 id="wrapper"
-                onMouseOver={this.onMouseOver.bind(this)}
-                onMouseLeave={this.onMouseLeave.bind(this)}
+                onMouseOver={(ev) => {
+                    this.onMouseOver();
+                    ev.stopPropagation();
+                }}
+                onMouseLeave={(ev) => {
+                    this.onMouseLeave();
+                    ev.stopPropagation();
+                }}
                 ref={(el) => (this.wrapperEl = el)}
             >
-                <slot />
-
                 {this.createTooltip()}
             </div>
         );

--- a/packages/ketchup/src/components/kup-tooltip/readme.md
+++ b/packages/ketchup/src/components/kup-tooltip/readme.md
@@ -7,25 +7,25 @@
 
 ## Properties
 
-| Property         | Attribute        | Description                      | Type                | Default     |
-| ---------------- | ---------------- | -------------------------------- | ------------------- | ----------- |
-| `data`           | --               | Data for top section             | `TooltipData`       | `undefined` |
-| `detailData`     | --               | Data for the detail              | `TooltipDetailData` | `undefined` |
-| `detailTimeout`  | `detail-timeout` | Timeout for loadDetail           | `number`            | `800`       |
-| `layout`         | `layout`         | Layout used to display the items | `string`            | `'1'`       |
-| `loadTimeout`    | `load-timeout`   | Timeout for tooltip              | `number`            | `1000`      |
-| `relatedElement` | --               | Container element for tooltip    | `HTMLElement`       | `undefined` |
+| Property        | Attribute        | Description                      | Type                   | Default     |
+| --------------- | ---------------- | -------------------------------- | ---------------------- | ----------- |
+| `data`          | --               | Data for top section             | `TooltipData`          | `undefined` |
+| `detailData`    | --               | Data for the detail              | `TooltipDetailData`    | `undefined` |
+| `detailTimeout` | `detail-timeout` | Timeout for loadDetail           | `number`               | `800`       |
+| `layout`        | `layout`         | Layout used to display the items | `string`               | `'1'`       |
+| `loadTimeout`   | `load-timeout`   | Timeout for tooltip              | `number`               | `1000`      |
+| `relatedObject` | --               | Container element for tooltip    | `TooltipRelatedObject` | `undefined` |
 
 
 ## Events
 
-| Event                     | Description | Type                                             |
-| ------------------------- | ----------- | ------------------------------------------------ |
-| `kupActionCommandClicked` |             | `CustomEvent<{ actionCommand: TooltipAction; }>` |
-| `kupDefaultActionClicked` |             | `CustomEvent<{ obj: TooltipObject; }>`           |
-| `kupDefaultOptionClicked` |             | `CustomEvent<{ obj: TooltipObject; }>`           |
-| `kupTooltipLoadData`      |             | `CustomEvent<any>`                               |
-| `kupTooltipLoadDetail`    |             | `CustomEvent<any>`                               |
+| Event                     | Description | Type                                                    |
+| ------------------------- | ----------- | ------------------------------------------------------- |
+| `kupActionCommandClicked` |             | `CustomEvent<{ actionCommand: TooltipAction; }>`        |
+| `kupDefaultActionClicked` |             | `CustomEvent<{ obj: TooltipObject; }>`                  |
+| `kupDefaultOptionClicked` |             | `CustomEvent<{ obj: TooltipObject; }>`                  |
+| `kupTooltipLoadData`      |             | `CustomEvent<{ relatedObject: TooltipRelatedObject; }>` |
+| `kupTooltipLoadDetail`    |             | `CustomEvent<{ relatedObject: TooltipRelatedObject; }>` |
 
 
 ## Dependencies

--- a/packages/ketchup/src/components/kup-tooltip/readme.md
+++ b/packages/ketchup/src/components/kup-tooltip/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                      | Type                | Default     |
-| --------------- | ---------------- | -------------------------------- | ------------------- | ----------- |
-| `data`          | --               | Data for top section             | `TooltipData`       | `undefined` |
-| `detailData`    | --               | Data for the detail              | `TooltipDetailData` | `undefined` |
-| `detailTimeout` | `detail-timeout` | Timeout for loadDetail           | `number`            | `800`       |
-| `layout`        | `layout`         | Layout used to display the items | `string`            | `'1'`       |
-| `loadTimeout`   | `load-timeout`   | Timeout for tooltip              | `number`            | `1000`      |
+| Property         | Attribute        | Description                      | Type                | Default     |
+| ---------------- | ---------------- | -------------------------------- | ------------------- | ----------- |
+| `data`           | --               | Data for top section             | `TooltipData`       | `undefined` |
+| `detailData`     | --               | Data for the detail              | `TooltipDetailData` | `undefined` |
+| `detailTimeout`  | `detail-timeout` | Timeout for loadDetail           | `number`            | `800`       |
+| `layout`         | `layout`         | Layout used to display the items | `string`            | `'1'`       |
+| `loadTimeout`    | `load-timeout`   | Timeout for tooltip              | `number`            | `1000`      |
+| `relatedElement` | --               | Container element for tooltip    | `HTMLElement`       | `undefined` |
 
 
 ## Events

--- a/packages/ketchup/src/index.html
+++ b/packages/ketchup/src/index.html
@@ -95,6 +95,8 @@
         <br />
         <a href="nav-bar.html">Ketchup nav bar</a>
         <br />
+        <a href="tooltip.html">Tooltip tests</a>
+        <br />
         <kup-text-field
             id="int1"
             is-clearable

--- a/packages/ketchup/src/tooltip.html
+++ b/packages/ketchup/src/tooltip.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+    <head>
+        <meta charset="utf-8" />
+
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+        />
+
+        <title>Ketchup tooltip tests</title>
+
+        <script type="module" src="/build/ketchup.esm.js"></script>
+        <script nomodule src="/build/ketchup.js"></script>
+
+        <link
+            href="https://cdn.materialdesignicons.com/4.5.95/css/materialdesignicons.min.css"
+            rel="stylesheet"
+            type="text/css"
+        />
+
+        <style>
+            #container {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+            }
+
+            #container > div {
+                margin: 1rem;
+            }
+        </style>
+    </head>
+
+    <body>
+        <div id="container">
+            <h3>Elements</h3>
+            <kup-tooltip id="globaltooltip"></kup-tooltip>
+            <div style="display: inline-flex;">
+                <div id="rosso" style="margin: 2px; background-color: red; width: 150px; height: 150px;"></div>
+                <div id="verde" style="margin: 2px; background-color: green; width: 150px; height: 150px;"></div>
+                <div id="blu" style="margin: 2px; background-color: blue; width: 150px; height: 150px;"></div>
+                <script src="/assets/tooltip.js"></script>
+            </div>
+        </div>
+    </body>
+</html>

--- a/packages/ketchup/src/utils/recalc-position.ts
+++ b/packages/ketchup/src/utils/recalc-position.ts
@@ -51,8 +51,8 @@ export async function runRecalc(el: HTMLElement) {
     if (!el.isConnected || !el.classList.contains('dynamic-position-active')) {
         return;
     }
-    let offsetH: number = el.clientHeight;
-    let offsetW: number = el.clientWidth;
+    let offsetH: number = el['offsetH'];
+    let offsetW: number = el['offsetW'];
     const rect = el.anchorEl.getBoundingClientRect();
 
     el.style.top = ``;

--- a/packages/ketchup/src/utils/recalc-position.ts
+++ b/packages/ketchup/src/utils/recalc-position.ts
@@ -9,23 +9,33 @@
 export function positionRecalc(
     el: any,
     anchorEl: HTMLElement,
-    margin?: number
+    margin?: number,
+    offsetH?: number,
+    offsetW?: number
 ) {
     el.classList.add('dynamic-position');
     anchorEl.classList.add('dynamic-position-anchor');
     if (!margin) {
         margin = 0;
     }
+    if (!offsetH) {
+        offsetH = el.clientHeight;
+    }
+    if (!offsetW) {
+        offsetW = el.clientWidth;
+    }
     el['anchorEl'] = anchorEl;
     el['anchorMargin'] = margin;
+    el['offsetH'] = offsetH;
+    el['offsetW'] = offsetW;
 
     var mutObserver = new MutationObserver(function (mutations) {
         let target: any = mutations[0].target;
         if (target.classList.contains('dynamic-position-active')) {
             el['anchorInterval'] = setInterval(
                 function () {
-                    let offsetH: number = el.clientHeight;
-                    let offsetW: number = el.clientWidth;
+                    let offsetH: number = el['offsetH'];
+                    let offsetW: number = el['offsetW'];
                     const rect = el.anchorEl.getBoundingClientRect();
 
                     el.style.top = ``;

--- a/packages/ketchup/stencil.config.ts
+++ b/packages/ketchup/stencil.config.ts
@@ -24,6 +24,9 @@ export const config: Config = {
         {
             src: 'nav-bar.html',
         },
+        {
+            src: 'tooltip.html',
+        },
     ],
 
     namespace: 'ketchup',


### PR DESCRIPTION
kup-data-table: manage one kup-tooltip element for all datatable cells; it moves when onMouseOver event fires 