### PR TITLE
Fixed columns example with totals in showcase

### DIFF
--- a/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
+++ b/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
@@ -72,6 +72,10 @@ export default {
         showGrid: 'Col',
         tableHeight: '200px',
         tableWidth: '400px',
+        totals: {
+          FLD0: 'Count',
+          FLD1: 'Count',
+        },
       },
       fixedData3: {
         data: groupDataTable,


### PR DESCRIPTION
Example name: Fixed columns (2 columns and show-grid = Col)