### PR TITLE
data-table-fixes [menu, fixed horizontal totals, fixed columns and cells borders]

### DIFF
--- a/packages/ketchup-showcase/.eslintrc.js
+++ b/packages/ketchup-showcase/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
 
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off"
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    "linebreak-style": "off"
   },
 
   parserOptions: {

--- a/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
+++ b/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
@@ -49,10 +49,16 @@ h3 {
       :data.prop="fixedData7"
     ></kup-lazy>
 
-    <h3>When we have totals (fixed columns (4) rows (4))</h3>
+    <h3>With totals (fixed columns (4) rows (4))</h3>
     <kup-lazy
         component-name="kup-data-table"
         :data.prop="fixedDataTotals"
+    />
+
+    <h3>With hidden table header (fixed columns (4) rows (4))</h3>
+    <kup-lazy
+        component-name="kup-data-table"
+        :data.prop="fixedDataNoHeaders"
     />
   </div>
 </template>
@@ -164,6 +170,16 @@ export default {
           FLD4: 'Count',
           FLD5: 'Count',
         },
+      },
+      fixedDataNoHeaders: {
+        data: groupDataTable,
+        showFilters: true,
+        showHeader: false,
+        fixedColumns: '4',
+        fixedRows: '4',
+        showGrid: 'Complete',
+        tableHeight: '230px',
+        tableWidth: '450px',
       },
     };
   },

--- a/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
+++ b/packages/ketchup-showcase/src/views/advanced/datatable/examples/DatatableFixedColumnsRows.vue
@@ -48,6 +48,12 @@ h3 {
       component-name="kup-data-table"
       :data.prop="fixedData7"
     ></kup-lazy>
+
+    <h3>When we have totals (fixed columns (4) rows (4))</h3>
+    <kup-lazy
+        component-name="kup-data-table"
+        :data.prop="fixedDataTotals"
+    />
   </div>
 </template>
 
@@ -143,6 +149,21 @@ export default {
           },
         ],
         expandGroups: true,
+      },
+      fixedDataTotals: {
+        data: groupDataTable,
+        showFilters: true,
+        fixedColumns: '4',
+        fixedRows: '4',
+        showGrid: 'Complete',
+        tableHeight: '230px',
+        tableWidth: '450px',
+        totals: {
+          FLD2: 'Count',
+          FLD3: 'Count',
+          FLD4: 'Count',
+          FLD5: 'Count',
+        },
       },
     };
   },

--- a/packages/ketchup-showcase/vue.config.js
+++ b/packages/ketchup-showcase/vue.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  lintOnSave: false,
   // To correctly use History mode with Vue router, this property must be set to '/'
   // in order to allow webpack to produce correct chunks address when generating the output for the application.
   // However we must check if by setting this prop to '/' il compatible with CI service.

--- a/packages/ketchup-showcase/vue.config.js
+++ b/packages/ketchup-showcase/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  lintOnSave: false,
+  // If uncommented, this will disable all linting on all the showcase project. Use it carefully
+  // lintOnSave: false,
   // To correctly use History mode with Vue router, this property must be set to '/'
   // in order to allow webpack to produce correct chunks address when generating the output for the application.
   // However we must check if by setting this prop to '/' il compatible with CI service.

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3839,6 +3839,8 @@ export class KupDataTable {
 
             'custom-size':
                 this.tableHeight !== undefined || this.tableWidth !== undefined,
+
+            'border-top': !this.showHeader
         };
 
         tableClass[`density-${this.density}`] = true;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -544,7 +544,7 @@ export class KupDataTable {
     private tooltip: KupTooltip;
 
     /**
-     * Reference to the working area of teh table. This is the below-wrapper reference.
+     * Reference to the working area of the table. This is the below-wrapper reference.
      */
     private tableAreaRef: HTMLDivElement;
     private stickyTheadRef: any;
@@ -1343,6 +1343,8 @@ export class KupDataTable {
     }
 
     private updateFixedRowsAndColumnsCssVariables(): boolean {
+        // [ffbf] - Using getBoundingClientRect is mandatory since Firefox return a wrong value for ele.offsetHeight and witdh values
+
         // When grouping, the fixed rows and columns are not sticky
         if (this.isGrouping() || !this.tableRef) return false;
         let toRet: boolean = false;
@@ -1354,7 +1356,7 @@ export class KupDataTable {
             // The height must start from the height of the header
             let previousHeight: number = (this.tableRef.querySelector(
                 'thead > tr:first-of-type > th:first-of-type'
-            ) as HTMLTableCellElement).offsetHeight;
+            ) as HTMLTableCellElement).getBoundingClientRect().height;// [ffbf]
 
             // [CSSCount] - I must start from 1 since we are referencing html elements e not array (with CSS selectors starting from 1)
             for (let i = 1; i <= this.fixedRows && currentRow; i++) {
@@ -1363,7 +1365,7 @@ export class KupDataTable {
                     previousHeight + 'px'
                 );
                 previousHeight += (currentRow
-                    .children[0] as HTMLTableCellElement).offsetHeight;
+                    .children[0] as HTMLTableCellElement).getBoundingClientRect().height;// [ffbf]
                 currentRow = currentRow.nextElementSibling as HTMLTableRowElement;
             }
             toRet = true;
@@ -1385,7 +1387,7 @@ export class KupDataTable {
                     FixedCellsCSSVarsBase.columns + i,
                     previousWidth + 'px'
                 );
-                previousWidth += currentCell.offsetWidth;
+                previousWidth += currentCell.getBoundingClientRect().width;// [ffbf]
                 currentCell = currentCell.nextElementSibling as HTMLTableCellElement;
             }
             toRet = true;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -747,23 +747,17 @@ export class KupDataTable {
             entries.forEach((entry) => {
                 if (entry.target.tagName === 'TR') {
                     if (entry.isIntersecting) {
-                        entry.target.classList.add('in-viewport');
-                        if (entry.target.classList.contains('last-row')) {
-                            logMessage(
-                                this,
-                                'Last row entering the viewport, loading more elements.'
-                            );
-                            let delta =
-                                this.rows.length - this.currentRowsPerPage;
-                            if (delta < this.loadMoreStep) {
-                                this.currentRowsPerPage += delta;
-                            } else {
-                                this.currentRowsPerPage += this.loadMoreStep;
-                            }
-                            entry.target.classList.remove('last-row');
+                        logMessage(
+                            this,
+                            'Last row entering the viewport, loading more elements.'
+                        );
+                        let delta = this.rows.length - this.currentRowsPerPage;
+                        if (delta < this.loadMoreStep) {
+                            this.currentRowsPerPage += delta;
+                        } else {
+                            this.currentRowsPerPage += this.loadMoreStep;
                         }
-                    } else {
-                        entry.target.classList.remove('in-viewport');
+                        entry.target.classList.remove('last-row');
                     }
                 }
                 if (entry.target.tagName === 'THEAD') {
@@ -817,10 +811,7 @@ export class KupDataTable {
     private didRenderObservers() {
         let rows = this.rootElement.shadowRoot.querySelectorAll('tbody > tr');
         if (this.paginatedRowsLength < this.rowsLength && this.lazyLoadRows) {
-            rows[this.paginatedRowsLength - 1].classList.add('last-row');
-        }
-        for (let index = 0; index < rows.length; index++) {
-            this.intObserver.observe(rows[index]);
+            this.intObserver.observe(rows[this.paginatedRowsLength - 1]);
         }
     }
 
@@ -2571,13 +2562,21 @@ export class KupDataTable {
         if (this.multiSelection) {
             extraCells++;
             const fixedCellStyle = this.composeFixedCellStyleAndClass(
-              extraCells,
-              0,
-              extraCells
+                extraCells,
+                0,
+                extraCells
             );
 
-            selectRowCell = <td class={fixedCellStyle ? fixedCellStyle.fixedCellClasses : null}
-                                style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}/>;
+            selectRowCell = (
+                <td
+                    class={
+                        fixedCellStyle ? fixedCellStyle.fixedCellClasses : null
+                    }
+                    style={
+                        fixedCellStyle ? fixedCellStyle.fixedCellStyle : null
+                    }
+                />
+            );
         }
 
         let groupingCell = null;
@@ -2592,25 +2591,36 @@ export class KupDataTable {
         //                             style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}/>;
         // }
 
-        const footerCells = this.getVisibleColumns().map((column: Column, columnIndex) => {
-          const fixedCellStyle = this.composeFixedCellStyleAndClass(
-            columnIndex + 1 + extraCells,
-            0,
-            extraCells
-          );
+        const footerCells = this.getVisibleColumns().map(
+            (column: Column, columnIndex) => {
+                const fixedCellStyle = this.composeFixedCellStyleAndClass(
+                    columnIndex + 1 + extraCells,
+                    0,
+                    extraCells
+                );
 
-          return (
-            <td
-              class={fixedCellStyle ? fixedCellStyle.fixedCellClasses : null}
-              style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}>
-              {numberToFormattedStringNumber(
-                this.footer[column.name],
-                column.decimals,
-                column.obj ? column.obj.p : ''
-              )}
-            </td>
-          )
-        });
+                return (
+                    <td
+                        class={
+                            fixedCellStyle
+                                ? fixedCellStyle.fixedCellClasses
+                                : null
+                        }
+                        style={
+                            fixedCellStyle
+                                ? fixedCellStyle.fixedCellStyle
+                                : null
+                        }
+                    >
+                        {numberToFormattedStringNumber(
+                            this.footer[column.name],
+                            column.decimals,
+                            column.obj ? column.obj.p : ''
+                        )}
+                    </td>
+                );
+            }
+        );
 
         const footer = (
             <tfoot>
@@ -3840,7 +3850,7 @@ export class KupDataTable {
             'custom-size':
                 this.tableHeight !== undefined || this.tableWidth !== undefined,
 
-            'border-top': !this.showHeader
+            'border-top': !this.showHeader,
         };
 
         tableClass[`density-${this.density}`] = true;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -2563,25 +2563,54 @@ export class KupDataTable {
             // no footer
             return null;
         }
-        const footerCells = this.getVisibleColumns().map((column: Column) => (
-            <td>
-                {numberToFormattedStringNumber(
-                    this.footer[column.name],
-                    column.decimals,
-                    column.obj ? column.obj.p : ''
-                )}
-            </td>
-        ));
 
+        let extraCells = 0;
+
+        // Composes initial cells if necessary
         let selectRowCell = null;
         if (this.multiSelection) {
-            selectRowCell = <td />;
+            extraCells++;
+            const fixedCellStyle = this.composeFixedCellStyleAndClass(
+              extraCells,
+              0,
+              extraCells
+            );
+
+            selectRowCell = <td class={fixedCellStyle ? fixedCellStyle.fixedCellClasses : null}
+                                style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}/>;
         }
 
         let groupingCell = null;
         // if (this.isGrouping() && this.hasTotals()) {
-        //     groupingCell = <td />;
+        //     extraCells++;
+        //     const fixedCellStyle = this.composeFixedCellStyleAndClass(
+        //         extraCells,
+        //         0,
+        //         extraCells
+        //     );
+        //     groupingCell = <td class={fixedCellStyle ? fixedCellStyle.fixedCellClasses : null}
+        //                             style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}/>;
         // }
+
+        const footerCells = this.getVisibleColumns().map((column: Column, columnIndex) => {
+          const fixedCellStyle = this.composeFixedCellStyleAndClass(
+            columnIndex + 1 + extraCells,
+            0,
+            extraCells
+          );
+
+          return (
+            <td
+              class={fixedCellStyle ? fixedCellStyle.fixedCellClasses : null}
+              style={fixedCellStyle ? fixedCellStyle.fixedCellStyle : null}>
+              {numberToFormattedStringNumber(
+                this.footer[column.name],
+                column.decimals,
+                column.obj ? column.obj.p : ''
+              )}
+            </td>
+          )
+        });
 
         const footer = (
             <tfoot>

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
@@ -21,7 +21,8 @@ $sticky-cell--row-z-index: 4;
   position: sticky;
 
   // For fixed headers, we must set a different background and place the correct z-index to prevent overlapping.
-  thead & {
+  thead &,
+  tfoot & {
     background-color: var(--kup-title-background-color);
     color: var(--kup-title-color);
     z-index: #{$sticky-header--z-index};

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
@@ -52,8 +52,17 @@ $sticky-cell--row-z-index: 4;
   z-index: 1;
 }
 
-table.custom-size th.fixed-column {
-  z-index: 8;
+// For sticky header
+table.custom-size th {
+  position: sticky;
+  top: 0;
+  // When header cell is not fixed. we simply place its index as an higher number than any inside the table.
+  // This prevents non fixed table cells from overlapping the first th cells.
+  z-index: $sticky-header--z-index;
+
+  &.fixed-column {
+    z-index: $sticky-header--z-index + 1; // And when the cell is fixed, then we rise that same z-index by one unit to prevent menu of the th to slip underneath
+  }
 }
 
 tr:hover .fixed-row,

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-fixed-rows.scss
@@ -1,9 +1,4 @@
 //-------- Fixed columns and rows declarations --------
-/*
-* Section comments declarations.
-* [fcr-ff] - This is a workaround necessary to support correctly the Firefox browser,
-*
-*/
 
 // The z-index of the data table main wrapper.
 $table-below-wrapper--z-index: 0;
@@ -27,30 +22,6 @@ $sticky-cell--row-z-index: 4;
     color: var(--kup-title-color);
     z-index: #{$sticky-header--z-index};
   }
-}
-
-@mixin fixedRowSeparator($bottom-position) {
-  bottom: $bottom-position;
-  border-bottom: 1px solid var(--kup-border-color);
-  content: '';
-  height: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  width: auto;
-  z-index: 1;
-}
-
-@mixin fixedColumnSeparator($right-position) {
-  bottom: 0;
-  border-right: 1px solid var(--kup-border-color);
-  content: '';
-  height: auto;
-  position: absolute;
-  right: $right-position;
-  top: 0;
-  width: 0;
-  z-index: 1;
 }
 
 // For sticky header
@@ -88,32 +59,6 @@ tr.selected .fixed-column {
   @extend %fixedCellsBase;
   top: 0;
   z-index: $sticky-cell--row-z-index;
-
-  // When the cell must keep its border
-  thead &::after,
-  &.show-row-separator::after {
-    @include fixedRowSeparator(-1px);
-  }
-
-  // The after for the rows separator element fallback for Firefox and sticky rows
-  th::after {
-    @include fixedRowSeparator(0);
-    border-bottom: 2px solid var(--kup-border-color);
-    bottom: -2px;
-  }
-
-  // @see [fcr-ff]
-  @supports (-moz-appearance: none) {
-    .column-separation &::before {
-      @include fixedColumnSeparator(0);
-    }
-
-    .row-separation &::after {
-      @include fixedRowSeparator(
-        0
-      ); // marked as !important otherwise the previous declaration will take precedence
-    }
-  }
 }
 
 // For a fixed column
@@ -122,26 +67,6 @@ tr.selected .fixed-column {
   @extend %fixedCellsBase;
   left: 0;
   z-index: $sticky-cell--column-z-index; // Must be higher than row
-
-  // When the cell must keep its border
-  &.show-column-separator::before {
-    @include fixedColumnSeparator(-1px);
-  }
-
-  // This is a small fix for Firefox since it has a strange bug which "compresses" the content of the sticky cells
-  @supports (-moz-appearance: none) {
-    .column-separation &::before {
-      @include fixedColumnSeparator(0);
-    }
-
-    .row-separation &::after {
-      @include fixedRowSeparator(0);
-    }
-
-    .row-separation &:not(.fixed-row)::after {
-      bottom: -1px;
-    }
-  }
 
   // When there is both the column and the row fixed
   &.fixed-row {

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
@@ -37,12 +37,6 @@ table {
     width: 0; // [mandatory] See [1] [2]
   }
 
-  &.custom-size th {
-    position: sticky;
-    top: 0;
-    z-index: 7;
-  }
-
   &.row-separation > tbody > tr {
     border-bottom: 1px solid var(--kup-border-color);
   }

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
@@ -23,9 +23,9 @@
      */
 
 table {
-  // This is needed to avoid problems with fixed rows/columns
-  border-spacing: 0;
-  border-collapse: separate;
+  // [TFixed-1] - This is needed to avoid problems with fixed rows/columns
+  border-spacing: 0; // [TFixed-1]
+  border-collapse: separate; // [TFixed-1]
   color: var(--kup-text-color);
   font-size: var(--kup-font-size);
   min-width: intrinsic; /* Safari/WebKit uses a non-standard name */
@@ -219,7 +219,7 @@ thead {
     background-color: var(--kup-title-background-color);
     color: var(--kup-title-color);
     border: $common-th-border;
-    border-left: 0 none; // Importnat: only the first cell must have the border left, otherwise the th will have a visual 2px border between each other.
+    border-left: 0 none; // Important: only the first cell must have the border left, otherwise the th will have a visual 2px border between each other.
     border-bottom-width: 2px;
     box-sizing: border-box;
     padding: 0.5rem 0.3125rem;
@@ -233,21 +233,7 @@ thead {
     &:first-of-type {
       border-left: $common-th-border;
     }
-/*
-    // On Firefox, things changes TODO: remove
-    @supports (-moz-appearance: none) {
-      // The row separator:
-      &::after {
-        bottom: 0; // Is slightly placed to the bottom
-        left: -1px; // gets slightly bigger to cover the absence of a border-right
-      }
 
-      // The column separator
-      &::before {
-        content: none; // Is not rendered on firefox because it does not render right-border on thead.
-      }
-    }
-*/
     //---- Column name container ----
     $column-sort-margin: 0.5rem;
 

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
@@ -470,30 +470,21 @@ tbody {
 }
 
 tr {
-  &:not(:nth-child(1)) {
-    kup-checkbox {
-      display: none;
-      animation: fadeInFromNone 0.25s ease-out;
-    }
+  kup-checkbox,
+  kup-image {
+    display: flex;
   }
 
-  &.in-viewport {
-    kup-checkbox,
-    kup-image {
-      display: flex;
-    }
+  kup-button {
+    display: inline-block;
+  }
 
-    kup-button {
-      display: inline-block;
-    }
+  kup-progress-bar {
+    display: block;
+  }
 
-    kup-progress-bar {
-      display: block;
-    }
-
-    & .indent ~ kup-image {
-      display: inline-block;
-    }
+  & .indent ~ kup-image {
+    display: inline-block;
   }
 
   .indent {

--- a/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/modules/kup-data-table-main.scss
@@ -23,7 +23,9 @@
      */
 
 table {
-  border-collapse: collapse;
+  // This is needed to avoid problems with fixed rows/columns
+  border-spacing: 0;
+  border-collapse: separate;
   color: var(--kup-text-color);
   font-size: var(--kup-font-size);
   min-width: intrinsic; /* Safari/WebKit uses a non-standard name */
@@ -37,12 +39,41 @@ table {
     width: 0; // [mandatory] See [1] [2]
   }
 
-  &.row-separation > tbody > tr {
-    border-bottom: 1px solid var(--kup-border-color);
+  // The common border specification
+  $common-border: 1px solid var(--kup-border-color);
+
+  // By default, since border has been moved to the cells themselves, the first and last cell must always simulate the table border
+  > tbody > tr {
+    > td {
+      &:first-of-type {
+        border-left: $common-border;
+      }
+
+      &:last-of-type {
+        border-right: $common-border;
+      }
+    }
+
+    // ALso the last row must always have the border bottom property
+    &:last-of-type > td {
+      border-bottom: $common-border;
+    }
   }
 
+  // When table header is not visible the table needs a border to,
+  // so the first row gets added a border
+  &.border-top > tbody > tr:first-of-type > td {
+    border-top: $common-border;
+  }
+
+  // If row separation is specified, all rows gets a border bottom
+  &.row-separation > tbody > tr > td {
+    border-bottom: $common-border;
+  }
+
+  // If column separation is specified, all rows gets a border bottom
   &.column-separation > tbody > tr > td {
-    border-right: 1px solid var(--kup-border-color);
+    border-right: $common-border;
   }
 
   &.noGrid {
@@ -182,13 +213,14 @@ table {
 }
 
 thead {
-  border: 1px solid var(--kup-border-color);
-
   th {
+    $common-th-border: 1px solid var(--kup-border-color);
+
     background-color: var(--kup-title-background-color);
     color: var(--kup-title-color);
-    border-bottom: 2px solid var(--kup-border-color);
-    border-right: 1px solid var(--kup-border-color);
+    border: $common-th-border;
+    border-left: 0 none; // Importnat: only the first cell must have the border left, otherwise the th will have a visual 2px border between each other.
+    border-bottom-width: 2px;
     box-sizing: border-box;
     padding: 0.5rem 0.3125rem;
     text-overflow: ellipsis;
@@ -197,7 +229,12 @@ thead {
     white-space: nowrap;
     transition: background-color 0.25s ease;
 
-    // On Firefox, things changes
+    // The first cell must have border left to simulate table border.
+    &:first-of-type {
+      border-left: $common-th-border;
+    }
+/*
+    // On Firefox, things changes TODO: remove
     @supports (-moz-appearance: none) {
       // The row separator:
       &::after {
@@ -210,7 +247,7 @@ thead {
         content: none; // Is not rendered on firefox because it does not render right-border on thead.
       }
     }
-
+*/
     //---- Column name container ----
     $column-sort-margin: 0.5rem;
 
@@ -296,7 +333,6 @@ thead {
 }
 
 tbody {
-  border: 1px solid var(--kup-border-color);
   cursor: auto;
 
   tr {


### PR DESCRIPTION
## Table borders with fixed cells

Here is a biref explanation regarding the solution for fixed header and borders in kup-data-table.

All browsers have an interesting issue in which sticky cells in combination with `border-collapse: collapse;` will not keep the border in place.
A possible solution would be to use pseudo elements, but this will make you struggle with many different behaviors across
 different browser.

The most reliable solution is to set `border-collapse: separate;` in combination with `border-spacing: 0;` and apply the style of the borders to the single cells, since the table can be scrolled and is not reliable to have borders set onto the table itself, when the table must have sticky cells.
Therefore, inside these commits you will find a rework on how table borders are set in CSS.

I'm asking for your review and check if all use cases are respected. I have already done a check by comparing the actual deployed showcase and the local one.

## Fix for linting

I've also commited a little fix for linting.

Now different line breaks are no longer considered a warning.

Now the majority of warnings are something like the following line:
```
Delete `␍` (prettier/prettier) at src\views\advanced\datatable\examples\DatatableFixedColumnsRows.vue:184:7:
```