### PR TITLE
fix class name id of icon linked to kup-text-field

### DIFF
--- a/packages/ketchup/src/components/kup-text-field/kup-text-field.tsx
+++ b/packages/ketchup/src/components/kup-text-field/kup-text-field.tsx
@@ -321,10 +321,8 @@ export class KupTextField {
                     | HTMLTextAreaElement = f.querySelector(
                     '.mdc-text-field__input'
                 );
-                const icon: HTMLElement = f.querySelector(
-                    '.mdc-text-field__icon'
-                );
-                const clearIcon: HTMLElement = f.querySelector('.clear-icon');
+                const icon: HTMLElement = f.querySelector('.action');
+                const clearIcon: HTMLElement = f.querySelector('.clear');
                 if (inputEl) {
                     inputEl.onblur = (
                         e: FocusEvent & { target: HTMLInputElement }

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -31,7 +31,7 @@
         outline: none;
         padding: 0 7px;
         width: 24px;
-        &.clear-icon:hover {
+        &.clear:hover {
           background-color: var(--kup-danger-color);
         }
       }
@@ -59,7 +59,7 @@
         left: 36px;
       }
 
-      & .mdc-text-field__icon.clear-icon {
+      & .mdc-text-field__icon.clear {
         right: 0px;
         left: initial;
         position: absolute;
@@ -67,7 +67,7 @@
         transform: translateY(-50%);
       }
 
-      &.mdc-text-field--with-trailing-icon input ~ .clear-icon {
+      &.mdc-text-field--with-trailing-icon input ~ .clear {
         right: 26px;
       }
 

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -84,7 +84,7 @@ function setContent(props: Props) {
             <span
                 tabindex="0"
                 style={iconStyle}
-                class={`material-icons mdc-text-field__icon icon-container ${iconClass}`}
+                class={`material-icons mdc-text-field__icon icon-container action ${iconClass}`}
             ></span>
         );
     }
@@ -134,7 +134,7 @@ function setContent(props: Props) {
             {props.isClearable ? (
                 <span
                     tabindex="1"
-                    class="material-icons mdc-text-field__icon clear-icon icon-container clear"
+                    class="material-icons mdc-text-field__icon icon-container clear"
                 ></span>
             ) : undefined}
             {props.trailingIcon ? iconEl : undefined}


### PR DESCRIPTION
fix class name id of icon linked to kup-text-field, confused with clear icon