### PR TITLE
removed filter on hidden columns (kup-data-table); fix order values java-like

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -2271,7 +2271,7 @@ export class KupDataTable {
             this.getRows(),
             this.filters,
             this.globalFilterValue,
-            this.getColumns()
+            this.getVisibleColumns()
         );
         this.rowsLength = this.rowsPointLength();
     }

--- a/packages/ketchup/src/components/kup-tree/kup-tree.tsx
+++ b/packages/ketchup/src/components/kup-tree/kup-tree.tsx
@@ -1073,7 +1073,7 @@ export class KupTree {
             this.getRows(),
             this.filters,
             this.globalFilterValue,
-            this.getColumns(),
+            this.getVisibleColumns(),
             treeExpandedPropName,
             this.filtersColumnMenuInstance
         );

--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -123,9 +123,8 @@ export function buildProgressBarConfig(
         );
 
         if (progressbarCssVar) {
-            wrapperStyle[
-                '--kup-pb_' + toKebabCase(progressbarCssVars[i])
-            ] = progressbarCssVar;
+            wrapperStyle['--kup-pb_' + toKebabCase(progressbarCssVars[i])] =
+                progressbarCssVar;
         }
     }
 
@@ -523,10 +522,14 @@ export function compareValues(
  * This is meant as a replacement for the JavaScript function localCompare() which produces a slightly different result from
  * the Java version of compareTo().
  *
- * This function has been taken from the link below, but it is slightly improved.
- * @param t1
- * @param t2
- * @see https://stackoverflow.com/questions/60300935/javascript-localecompare-returns-different-result-than-java-compareto
+ * Re-implemented from java source method compareTo() of java.lang.String
+ * @param t1 firstString the first string to be compared
+ * @param t2 anotherString the another string to be compared to the first one
+ * @returns the value 0 if the anotherString is equal to
+ *          firstString; a value less than 0 if firstString
+ *          is lexicographically less than the anotherString; and a
+ *          value greater than 0 if firstString is
+ *          lexicographically greater than the anotherString.
  */
 function localCompareAsInJava(t1: string, t2: string): number {
     let t1Length = t1 == null ? 0 : t1.length;
@@ -538,11 +541,7 @@ function localCompareAsInJava(t1: string, t2: string): number {
         const c1 = t1[k];
         const c2 = t2[k];
         if (c1 !== c2) {
-            if (c1.charCodeAt(0) === 32) {
-                return c1.charCodeAt(0) + c2.charCodeAt(0);
-            } else {
-                return c1.charCodeAt(0) - c2.charCodeAt(0);
-            }
+            return c1.charCodeAt(0) - c2.charCodeAt(0);
         }
         k++;
     }

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -163,9 +163,8 @@ export class FiltersRows extends Filters {
                 getColumnByName(columns, key)
             );
 
-            const _filterIsNegative: boolean = this.filterIsNegative(
-                filterValue
-            );
+            const _filterIsNegative: boolean =
+                this.filterIsNegative(filterValue);
             let b1 = this.isFilterCompliantForCell(cell, filterValue, interval);
             let b2 = _filterIsNegative;
             if (
@@ -382,7 +381,7 @@ export class FiltersRows extends Filters {
             comp.getRows(),
             tmpFilters,
             globalFilterValue,
-            comp.getColumns(),
+            comp.getVisibleColumns(),
             columnFilters
         );
 


### PR DESCRIPTION
kup-data-table:
- globalFilter applyed on values contained only in visibile columns of the table
- checkboxes column filter bug: on click on a value, became selected 2 checkboxes; for solve this, modified compare strings function, like java (localCompareAsInJava()): took implementation of: java.lang.String.compareTo()