### PR TITLE
Bugfix: clickHandler and contextMenuHandler didn't return details when no action fired (kup-data-table).

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -2153,6 +2153,7 @@ export class KupDataTable {
                 return details;
             }
         }
+        return details;
     }
 
     private contextMenuHandler(e: MouseEvent): EventHandlerDetails {
@@ -2192,6 +2193,7 @@ export class KupDataTable {
                 return details;
             }
         }
+        return details;
     }
 
     private dblClickHandler(e: MouseEvent): EventHandlerDetails {


### PR DESCRIPTION
…n no action fired (kup-data-table).