### PR TITLE
Revert "Removed redundant dependency (ResizeObserver fully supported by browsers now, natively)." Apparently not.

### DIFF
--- a/packages/ketchup/package-lock.json
+++ b/packages/ketchup/package-lock.json
@@ -7963,6 +7963,11 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
+		"resize-observer": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.4.tgz",
+			"integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew=="
+		},
 		"resolve": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",

--- a/packages/ketchup/package.json
+++ b/packages/ketchup/package.json
@@ -51,6 +51,7 @@
         "interactjs": "^1.10.11",
         "jquery": "^3.6.0",
         "numeral": "^2.0.6",
+        "resize-observer": "^1.0.4",
         "vanilla-picker": "^2.12.1"
     },
     "devDependencies": {

--- a/packages/ketchup/src/managers/kup-manager/kup-manager-declarations.ts
+++ b/packages/ketchup/src/managers/kup-manager/kup-manager-declarations.ts
@@ -16,6 +16,7 @@ import type { KupSearch } from '../kup-search/kup-search';
 import type { KupTheme } from '../kup-theme/kup-theme';
 import type { KupThemeJSON } from '../kup-theme/kup-theme-declarations';
 import type { KupToolbar } from '../kup-toolbar/kup-toolbar';
+import type { ResizeObserver } from 'resize-observer';
 /**
  * Interface used to define the HTML element with Ketchup specific properties.
  */

--- a/packages/ketchup/src/managers/kup-manager/kup-manager.ts
+++ b/packages/ketchup/src/managers/kup-manager/kup-manager.ts
@@ -16,6 +16,7 @@ import type {
     KupManagerUtilities,
 } from './kup-manager-declarations';
 import type { ResizableKupComponent } from '../../types/GenericTypes';
+import type { ResizeObserverEntry } from 'resize-observer/lib/ResizeObserverEntry';
 import { KupDebug } from '../kup-debug/kup-debug';
 import { KupDynamicPosition } from '../kup-dynamic-position/kup-dynamic-position';
 import { KupInteract } from '../kup-interact/kup-interact';
@@ -24,6 +25,7 @@ import { KupObjects } from '../kup-objects/kup-objects';
 import { KupScrollOnHover } from '../kup-scroll-on-hover/kup-scroll-on-hover';
 import { KupTheme } from '../kup-theme/kup-theme';
 import { KupToolbar } from '../kup-toolbar/kup-toolbar';
+import { ResizeObserver } from 'resize-observer';
 import {
     KupLanguageDefaults,
     KupLanguageJSON,


### PR DESCRIPTION
This reverts commit 7c9f504681ea54a5b136710ae203bf00223debde.