### PR TITLE
Fix tsconfig and package json

### DIFF
--- a/packages/ketchup-react/package.json
+++ b/packages/ketchup-react/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@sme.up/ketchup-react",
     "version": "6.9.0-SNAPSHOT",
-    "exports": "./dist/index.js",
-    "types": "dist/index.d.ts",
+    "module": "dist/index.js",
+    "typings": "dist/index.d.ts",
     "keywords": [
         "smeup",
         "KetchUP showcase",
@@ -10,7 +10,6 @@
         "custom elements",
         "components"
     ],
-    "type": "module",
     "files": [
         "dist/"
     ],
@@ -23,14 +22,14 @@
     "dependencies": {
         "@sme.up/ketchup": "^6.8.0",
         "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "rimraf": "^3.0.2"
+        "react-dom": "18.2.0"
     },
     "devDependencies": {
-        "typescript": "4.2.3",
         "@types/geojson": "^7946.0.8",
         "@types/node": "18.0.0",
         "@types/react": "18.0.14",
-        "@types/react-dom": "18.0.5"
+        "@types/react-dom": "18.0.5",
+        "rimraf": "^3.0.2",
+        "typescript": "4.2.3"
     }
 }

--- a/packages/ketchup-react/tsconfig.json
+++ b/packages/ketchup-react/tsconfig.json
@@ -1,19 +1,15 @@
 {
     "compilerOptions": {
-        "allowSyntheticDefaultImports": true,
-        "allowUnreachableCode": false,
-        "declaration": true,
-        "experimentalDecorators": true,
-        "jsx": "react",
-        "lib": ["dom", "es2017"],
-        "moduleResolution": "node",
-        "module": "esnext",
-        "noUnusedLocals": false,
-        "noUnusedParameters": true,
-        "resolveJsonModule": true,
-        "target": "es2017",
-        "outDir": "./dist"
+      "target": "ESNext", 
+      "module": "ESNext",  
+      "declaration": true,
+      "esModuleInterop": true,
+      "forceConsistentCasingInFileNames": true,
+      "strict": true,                   
+      "skipLibCheck": true,
+      "jsx": "react",
+      "moduleResolution": "node",
+      "outDir": "dist"
     },
-    "include": ["src", "types/jsx.d.ts"],
-    "exclude": ["node_modules"]
-}
+    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  }


### PR DESCRIPTION
Fix ketchup-react package build process. Use `esnext` and declare module and typings files into `package.json`.