### PR TITLE
Test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+name: Ketchup test
+
+on:
+  push:
+    branches: add_github_action
+  pull_request:
+    branches: 
+     - develop
+     - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: 16.13.0
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Run lerna bootstrap
+      run: npm run lerna bootstrap
+
+    - name: Run build
+      run: npm run k:build
+
+    - name: Execute tests
+      run: npm run k:test:unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,7 @@
 name: Ketchup test
 
 on:
-  push:
-    branches: add_github_action
+  workflow_dispatch:
   pull_request:
     branches: 
      - develop

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Install dependencies
+      run: npm install
+
     - name: Run lerna bootstrap
       run: npm run lerna bootstrap
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: 16.13.0
+        node-version: [16.13.0]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This workflow will test ketchup by using the command: `npm run k:test:unit`
It will be triggered on PR opening against the master and develop branches.
In addiction you can launch the workflow also through the github Actions panel.
