### PR TITLE
IF update kup-image-list.tsx

### DIFF
--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -487,7 +487,7 @@ export class KupImageList {
             ...gridColumnsStyle,
         };
 
-        if (this.rows !== null) {
+        if (this.rows != null && this.rows > 0) {
             const gridRowsStyle = {
                 'grid-template-rows': `repeat(${this.rows}, minmax(0px, 1fr))`,
                 'grid-auto-flow': `column`,


### PR DESCRIPTION
When passed by WebUP, the int row value was 0 by default (being int a primitive type), so the if was basically bypassed every time the iml view was set to Ketchup, ruining the whole iml grid.