### PR TITLE
feat/f-button black mode

### DIFF
--- a/packages/ketchup/src/button.html
+++ b/packages/ketchup/src/button.html
@@ -114,6 +114,15 @@
             styling="flat"
             disabled
         ></kup-button>
+        <h5>Neutral : Black mode</h5>
+        <div style="background-color: #262626; padding: 16px">
+            <kup-button
+                label="Flat"
+                class="kup-neutral"
+                styling="flat"
+                black-mode
+            ></kup-button>
+        </div>
 
         <h4>Danger:</h4>
         <kup-button label="Raised" class="kup-danger"></kup-button>

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -498,6 +498,11 @@ export namespace Components {
     }
     interface KupButton {
         /**
+          * When set to true, the label will be on the left of the component.
+          * @default false
+         */
+        "blackMode": boolean;
+        /**
           * Sets the type of the button.
           * @default null
          */
@@ -5888,6 +5893,11 @@ declare namespace LocalJSX {
         "swipeDisabled"?: boolean;
     }
     interface KupButton {
+        /**
+          * When set to true, the label will be on the left of the component.
+          * @default false
+         */
+        "blackMode"?: boolean;
         /**
           * Sets the type of the button.
           * @default null

--- a/packages/ketchup/src/components/kup-button/kup-button.tsx
+++ b/packages/ketchup/src/components/kup-button/kup-button.tsx
@@ -99,6 +99,11 @@ export class KupButton {
      */
     @Prop() label: string = null;
     /**
+     * When set to true, the label will be on the left of the component.
+     * @default false
+     */
+    @Prop() blackMode: boolean = false;
+    /**
      * When set, the button will show this icon, if icon/image not found.
      * @default null
      */
@@ -292,6 +297,7 @@ export class KupButton {
             large: this.rootElement.classList.contains('kup-large')
                 ? true
                 : false,
+            blackMode: this.blackMode,
             neutral: this.rootElement.classList.contains('kup-neutral')
                 ? true
                 : false,

--- a/packages/ketchup/src/f-components/f-button/f-button-declarations.ts
+++ b/packages/ketchup/src/f-components/f-button/f-button-declarations.ts
@@ -14,6 +14,7 @@ export interface FButtonProps extends FComponent {
     placeholderIcon?: string;
     label?: string;
     large?: boolean;
+    blackMode?: boolean;
     neutral?: boolean;
     onClick?: (event: MouseEvent) => void;
     onBlur?: (event: FocusEvent) => void;

--- a/packages/ketchup/src/f-components/f-button/f-button.scss
+++ b/packages/ketchup/src/f-components/f-button/f-button.scss
@@ -514,6 +514,14 @@
         height: var(--kup_button_spinner_height);
       }
     }
+    &.#{$kup-class-black-mode} {
+      .button {
+        --kup_button_text_color: var(--kup-gray-color-0);
+      }
+      .icon-button {
+        --kup_button_text_color: var(--kup-gray-color-0);
+      }
+    }
   }
 
   &.#{$kup-class-full-height} {

--- a/packages/ketchup/src/f-components/f-button/f-button.tsx
+++ b/packages/ketchup/src/f-components/f-button/f-button.tsx
@@ -37,6 +37,7 @@ export const FButton: FunctionalComponent<FButtonProps> = (
         'kup-success': props.success,
         'kup-warning': props.warning,
         'kup-neutral': props.neutral,
+        'kup-black-mode': props.blackMode,
         [props.wrapperClass]: !!props.wrapperClass,
     };
     return (

--- a/packages/ketchup/src/style/global.scss
+++ b/packages/ketchup/src/style/global.scss
@@ -9,6 +9,7 @@ $kup-class-secondary: 'kup-secondary'; // Sets the primary color to --kup-second
 $kup-class-success: 'kup-success'; // Sets the primary color to --kup-success-color.
 $kup-class-warning: 'kup-warning'; // Sets the primary color to --kup-warning-color.
 $kup-class-light-mode: 'kup-light-mode'; // Sets the component in light mode where background and foreground are inverted.
+$kup-class-black-mode: 'kup-black-mode'; // Sets the component in black mode where background is fixed on black.
 
 // New color related variables.
 $kup-class-red: 'kup-accent-red'; // Sets the primary color to --kup-accent-red-color.


### PR DESCRIPTION
Fixed black background ( dark or lightdark bg )
- The button will be rendered for the fixed dark background such as the navbar thanks to the blackMode prop