### PR TITLE
Feat/image list/responsive columns prop

### DIFF
--- a/packages/ketchup/src/assets/image-list.js
+++ b/packages/ketchup/src/assets/image-list.js
@@ -1179,6 +1179,7 @@ const data = [
 
 const imageList = document.querySelector('kup-image-list');
 imageList.data = data;
+imageList.columns = [3, 7, 10];
 imageList.selectable = true;
 
 document.addEventListener('kup-imagelist-click', (e) => {

--- a/packages/ketchup/src/assets/image-list.js
+++ b/packages/ketchup/src/assets/image-list.js
@@ -1179,8 +1179,17 @@ const data = [
 
 const imageList = document.querySelector('kup-image-list');
 imageList.data = data;
-imageList.columns = [3, 7, 10];
-imageList.selectable = true;
+imageList.columns = [
+    {
+        value: 5,
+    },
+    {
+        value: 3,
+    },
+    {
+        value: 2,
+    },
+];
 
 document.addEventListener('kup-imagelist-click', (e) => {
     console.log(e);

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -2694,7 +2694,7 @@ export namespace Components {
           * Number of columns to display in the grid layout.
           * @default null
          */
-        "columns": number;
+        "columns": KupDataNode[];
         /**
           * Custom style of the component.
           * @default ""
@@ -7930,7 +7930,7 @@ declare namespace LocalJSX {
           * Number of columns to display in the grid layout.
           * @default null
          */
-        "columns"?: number;
+        "columns"?: KupDataNode[];
         /**
           * Custom style of the component.
           * @default ""

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -42,8 +42,8 @@ import {
 import { KupStore } from '../kup-state/kup-store';
 import { KupImageListState } from './kup-image-list-state';
 import { TreeNodePath } from '../kup-tree/kup-tree-declarations';
-import { KupBadge } from '../kup-badge/kup-badge';
 import { KupPointerEventTypes } from '../../managers/kup-interact/kup-interact-declarations';
+import { KupDataNode } from '../../managers/kup-data/kup-data-declarations';
 
 @Component({
     tag: 'kup-image-list',
@@ -110,7 +110,7 @@ export class KupImageList {
      * Number of columns to display in the grid layout.
      * @default null
      */
-    @Prop() columns: number = null;
+    @Prop() columns: KupDataNode[] = null;
     /**
      * Custom style of the component.
      * @default ""
@@ -509,9 +509,31 @@ export class KupImageList {
 
     render() {
         const hasNavigation = !!this.currentNode;
-        const gridColumnsStyle = {
-            'grid-template-columns': `repeat(${this.columns}, minmax(0px, 1fr))`,
-        };
+        let gridColumnsStyle: { [key: string]: string } = {};
+
+        if (this.columns) {
+            if (typeof this.columns === 'number') {
+                gridColumnsStyle[
+                    'grid-template-columns'
+                ] = `repeat(${this.columns}, minmax(0px, 1fr))`;
+            } else if (this.columns.length === 1) {
+                gridColumnsStyle[
+                    'grid-template-columns'
+                ] = `repeat(${this.columns[0]}, minmax(0px, 1fr))`;
+            } else if (this.columns.length === 2) {
+                gridColumnsStyle = {
+                    '--kup-imagelist-columns-mobile': `${this.columns[0]}`,
+                    '--kup-imagelist-columns-tablet': `${this.columns[0]}`,
+                    '--kup-imagelist-columns-desktop': `${this.columns[1]}`,
+                };
+            } else if (this.columns.length === 3) {
+                gridColumnsStyle = {
+                    '--kup-imagelist-columns-mobile': `${this.columns[0]}`,
+                    '--kup-imagelist-columns-tablet': `${this.columns[1]}`,
+                    '--kup-imagelist-columns-desktop': `${this.columns[2]}`,
+                };
+            }
+        }
         let combinedGridStyle: { [key: string]: string } = {
             ...gridColumnsStyle,
         };

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -510,7 +510,6 @@ export class KupImageList {
     render() {
         const hasNavigation = !!this.currentNode;
         let gridColumnsStyle: { [key: string]: string } = {};
-
         if (this.columns) {
             if (typeof this.columns === 'number') {
                 gridColumnsStyle[
@@ -519,18 +518,18 @@ export class KupImageList {
             } else if (this.columns.length === 1) {
                 gridColumnsStyle[
                     'grid-template-columns'
-                ] = `repeat(${this.columns[0]}, minmax(0px, 1fr))`;
+                ] = `repeat(${this.columns[0].value}, minmax(0px, 1fr))`;
             } else if (this.columns.length === 2) {
                 gridColumnsStyle = {
-                    '--kup-imagelist-columns-mobile': `${this.columns[0]}`,
-                    '--kup-imagelist-columns-tablet': `${this.columns[0]}`,
-                    '--kup-imagelist-columns-desktop': `${this.columns[1]}`,
+                    '--kup-imagelist-columns-mobile': `${this.columns[0].value}`,
+                    '--kup-imagelist-columns-tablet': `${this.columns[0].value}`,
+                    '--kup-imagelist-columns-desktop': `${this.columns[1].value}`,
                 };
             } else if (this.columns.length === 3) {
                 gridColumnsStyle = {
-                    '--kup-imagelist-columns-mobile': `${this.columns[0]}`,
-                    '--kup-imagelist-columns-tablet': `${this.columns[1]}`,
-                    '--kup-imagelist-columns-desktop': `${this.columns[2]}`,
+                    '--kup-imagelist-columns-mobile': `${this.columns[0].value}`,
+                    '--kup-imagelist-columns-tablet': `${this.columns[1].value}`,
+                    '--kup-imagelist-columns-desktop': `${this.columns[2].value}`,
                 };
             }
         }

--- a/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
+++ b/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
@@ -15,6 +15,10 @@
 */
 
 :host {
+  --kup_imagelist_columns_mobile: var(--kup-imagelist-columns-mobile, 4);
+  --kup_imagelist_columns_tablet: var(--kup-imagelist-columns-tablet, 6);
+  --kup_imagelist_columns_desktop: var(--kup-imagelist-columns-desktop, 8);
+
   --kup_imagelist_background_color: var(
     --kup-imagelist-background-color,
     transparent
@@ -122,7 +126,7 @@
   display: grid;
   grid-gap: var(--kup_imagelist_grid_gap);
   grid-template-columns: repeat(
-    var(--kup_imagelist_columns, 4),
+    var(--kup-imagelist-columns-mobile, var(--kup_imagelist_columns_mobile)),
     minmax(0px, 1fr)
   );
   margin-top: 1em;
@@ -193,13 +197,22 @@
 }
 
 @media screen and (min-width: 678px) {
-  :host {
-    --kup_imagelist_columns: var(--kup-imagelist-columns, 8);
-  }
-
   .image-list {
     grid-template-columns: repeat(
-      var(--kup_imagelist_columns, 8),
+      var(--kup-imagelist-columns-tablet, var(--kup_imagelist_columns_tablet)),
+      minmax(0px, 1fr)
+    );
+    grid-gap: var(--kup-space-05);
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .image-list {
+    grid-template-columns: repeat(
+      var(
+        --kup-imagelist-columns-desktop,
+        var(--kup_imagelist_columns_desktop)
+      ),
       minmax(0px, 1fr)
     );
     grid-gap: var(--kup-space-05);


### PR DESCRIPTION
THIS PR NEEDS TO BE ACCEPTED WITH ITS WEBUP.JSF COUNTERPART:
[(https://github.com/smeup/webup-project/compare/develop...Add_IMLResponsiveColumns?expand=1)](https://github.com/smeup/webup-project/compare/develop...Add_IMLResponsiveColumns?expand=1)

Prop Column for kup-image-list is now a KupDataNode and has 3 possibilities for its value:
- "N" : acts as the previous one
- "N;N" : first number is used for phone and tablet, second one for pc
- "N;N;N" : first number for phone, second for tablet, third for pc