### PR TITLE
feat / change content width default

### DIFF
--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -54,6 +54,10 @@
       --kup-textfield-extrasmall-padding,
       0 4px 0 8px
     );
+    --kup_textfield_medium_padding: var(
+      --kup-textfield-medium-padding,
+      0 var(--kup-space-05)
+    );
     --kup_textfield_extrasmall_font_size: var(
       --kup-textfield-extrasmall-font-size,
       12px
@@ -71,7 +75,7 @@
       var(--kup-text-main)
     );
     --kup_textfield_text_align: var(--kup-textfield-text-align, start);
-    --kup_textfield_width: var(--kup-textfield-width, fit-content);
+    --kup_textfield_width: var(--kup-textfield-width, 100%);
     --mdc-theme-primary: var(--kup_textfield_primary_color);
     --mdc-shape-small: 0px;
     --kup_textfield_border_radius: var(--kup-textfield-border-radius, unset);
@@ -172,7 +176,7 @@
       border-bottom: 1px solid var(--kup_textfield_border_color);
       background-color: var(--kup_textfield_background_color);
       align-items: center;
-      padding: 0px var(--kup-space-05);
+      padding: var(--kup_textfield_medium_padding);
 
       input {
         @include kup-body-compact-01;


### PR DESCRIPTION
restore default for textfield as 100%.
Fit content will be passed in the client where needed