### PR TITLE
fix: handle error on kup-comboboxe and kup-autocomplete

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -444,8 +444,8 @@ export class KupAutocomplete {
             this.#closeList();
             return false;
         }
-        const hasError = this.error.trim().length > 0;
-        const hasAlert = this.alert.trim().length > 0;
+        const hasError = this.error?.trim().length > 0;
+        const hasAlert = this.alert?.trim().length > 0;
         const topOffset = hasError || hasAlert ? -20 : 0;
         this.#textfieldWrapper.classList.add('toggled');
         this.#listEl.menuVisible = true;

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -422,8 +422,8 @@ export class KupCombobox {
             return;
         }
         // Manage list open while helperline is displayed
-        const hasError = this.error.trim().length > 0;
-        const hasAlert = this.alert.trim().length > 0;
+        const hasError = this.error?.trim().length > 0;
+        const hasAlert = this.alert?.trim().length > 0;
         const topOffset = hasError || hasAlert ? -20 : 0;
         this.#textfieldWrapper.classList.add('toggled');
         this.#listEl.menuVisible = true;


### PR DESCRIPTION
bugfix: 
Component Autocomplete e combobox error: `kup-autocomplete: Uncaught TypeError: Cannot read properties of undefined (reading 'trim')`