### PR TITLE
Kup-cell - New Prop and Event - ShowSubmit

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -22,7 +22,7 @@ import { KupCalendarData, KupCalendarDateClickEventPayload, KupCalendarEventClic
 import { KupCardClickPayload, KupCardData, KupCardEventPayload, KupCardFamily } from "./components/kup-card/kup-card-declarations";
 import { KupCardListClickEventPayload, KupCardListData } from "./components/kup-card-list/kup-card-list-declarations";
 import { FCellPadding } from "./f-components/f-cell/f-cell-declarations";
-import { KupCellSubmitButtonPosition } from "./components/kup-cell/kup-cell-declarations";
+import { KupCellSubmitButtonPosition, KupCellSubmitClickEventPayload } from "./components/kup-cell/kup-cell-declarations";
 import { ChartAspect, ChartAxis, ChartOfflineMode, ChartSerie, ChartTitle, ChartType, KupChartClickEvent, KupChartSort, KupChartTrendlines } from "./components/kup-chart/kup-chart-declarations";
 import { KupCheckboxEventPayload } from "./components/kup-checkbox/kup-checkbox-declarations";
 import { KupChipChangeEventPayload, KupChipEventPayload, KupChipNode } from "./components/kup-chip/kup-chip-declarations";
@@ -80,7 +80,7 @@ export { KupCalendarData, KupCalendarDateClickEventPayload, KupCalendarEventClic
 export { KupCardClickPayload, KupCardData, KupCardEventPayload, KupCardFamily } from "./components/kup-card/kup-card-declarations";
 export { KupCardListClickEventPayload, KupCardListData } from "./components/kup-card-list/kup-card-list-declarations";
 export { FCellPadding } from "./f-components/f-cell/f-cell-declarations";
-export { KupCellSubmitButtonPosition } from "./components/kup-cell/kup-cell-declarations";
+export { KupCellSubmitButtonPosition, KupCellSubmitClickEventPayload } from "./components/kup-cell/kup-cell-declarations";
 export { ChartAspect, ChartAxis, ChartOfflineMode, ChartSerie, ChartTitle, ChartType, KupChartClickEvent, KupChartSort, KupChartTrendlines } from "./components/kup-chart/kup-chart-declarations";
 export { KupCheckboxEventPayload } from "./components/kup-checkbox/kup-checkbox-declarations";
 export { KupChipChangeEventPayload, KupChipEventPayload, KupChipNode } from "./components/kup-chip/kup-chip-declarations";
@@ -4516,6 +4516,10 @@ export interface KupCardListCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLKupCardListElement;
 }
+export interface KupCellCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLKupCellElement;
+}
 export interface KupChartCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLKupChartElement;
@@ -4859,7 +4863,18 @@ declare global {
         prototype: HTMLKupCardListElement;
         new (): HTMLKupCardListElement;
     };
+    interface HTMLKupCellElementEventMap {
+        "kup-cell-submit-click": KupCellSubmitClickEventPayload;
+    }
     interface HTMLKupCellElement extends Components.KupCell, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLKupCellElementEventMap>(type: K, listener: (this: HTMLKupCellElement, ev: KupCellCustomEvent<HTMLKupCellElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLKupCellElementEventMap>(type: K, listener: (this: HTMLKupCellElement, ev: KupCellCustomEvent<HTMLKupCellElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLKupCellElement: {
         prototype: HTMLKupCellElement;
@@ -6529,6 +6544,7 @@ declare namespace LocalJSX {
           * @default false
          */
         "dragEnabled"?: boolean;
+        "onKup-cell-submit-click"?: (event: KupCellCustomEvent<KupCellSubmitClickEventPayload>) => void;
         /**
           * Show submit button
          */

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -957,6 +957,10 @@ export namespace Components {
           * @param props - Object containing props that will be set to the component.
          */
         "setProps": (props: GenericObject) => Promise<void>;
+        /**
+          * Show submit button
+         */
+        "showSubmit": boolean;
     }
     interface KupChart {
         /**
@@ -6519,6 +6523,10 @@ declare namespace LocalJSX {
           * @default false
          */
         "dragEnabled"?: boolean;
+        /**
+          * Show submit button
+         */
+        "showSubmit"?: boolean;
     }
     interface KupChart {
         /**

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -22,6 +22,7 @@ import { KupCalendarData, KupCalendarDateClickEventPayload, KupCalendarEventClic
 import { KupCardClickPayload, KupCardData, KupCardEventPayload, KupCardFamily } from "./components/kup-card/kup-card-declarations";
 import { KupCardListClickEventPayload, KupCardListData } from "./components/kup-card-list/kup-card-list-declarations";
 import { FCellPadding } from "./f-components/f-cell/f-cell-declarations";
+import { KupCellSubmitButtonPosition } from "./components/kup-cell/kup-cell-declarations";
 import { ChartAspect, ChartAxis, ChartOfflineMode, ChartSerie, ChartTitle, ChartType, KupChartClickEvent, KupChartSort, KupChartTrendlines } from "./components/kup-chart/kup-chart-declarations";
 import { KupCheckboxEventPayload } from "./components/kup-checkbox/kup-checkbox-declarations";
 import { KupChipChangeEventPayload, KupChipEventPayload, KupChipNode } from "./components/kup-chip/kup-chip-declarations";
@@ -79,6 +80,7 @@ export { KupCalendarData, KupCalendarDateClickEventPayload, KupCalendarEventClic
 export { KupCardClickPayload, KupCardData, KupCardEventPayload, KupCardFamily } from "./components/kup-card/kup-card-declarations";
 export { KupCardListClickEventPayload, KupCardListData } from "./components/kup-card-list/kup-card-list-declarations";
 export { FCellPadding } from "./f-components/f-cell/f-cell-declarations";
+export { KupCellSubmitButtonPosition } from "./components/kup-cell/kup-cell-declarations";
 export { ChartAspect, ChartAxis, ChartOfflineMode, ChartSerie, ChartTitle, ChartType, KupChartClickEvent, KupChartSort, KupChartTrendlines } from "./components/kup-chart/kup-chart-declarations";
 export { KupCheckboxEventPayload } from "./components/kup-checkbox/kup-checkbox-declarations";
 export { KupChipChangeEventPayload, KupChipEventPayload, KupChipNode } from "./components/kup-chip/kup-chip-declarations";
@@ -961,6 +963,10 @@ export namespace Components {
           * Show submit button
          */
         "showSubmit": boolean;
+        /**
+          * Submit button position, default is right
+         */
+        "submitPosition": KupCellSubmitButtonPosition;
     }
     interface KupChart {
         /**
@@ -6527,6 +6533,10 @@ declare namespace LocalJSX {
           * Show submit button
          */
         "showSubmit"?: boolean;
+        /**
+          * Submit button position, default is right
+         */
+        "submitPosition"?: KupCellSubmitButtonPosition;
     }
     interface KupChart {
         /**

--- a/packages/ketchup/src/components/kup-calendar/readme.md
+++ b/packages/ketchup/src/components/kup-calendar/readme.md
@@ -2,25 +2,28 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
-| Property | Attribute | Description | Type | Default |
-| --- | --- | --- | --- | --- |
-| `currentDate` | `current-date` | Sets the initial date of the calendar. Must be in ISO format (YYYY-MM-DD). | `string` | `null` |
-| `customStyle` | `custom-style` | Custom style of the component. | `string` | `''` |
-| `data` | -- | Actual data of the calendar. | `KupCalendarData` | `null` |
-| `editableEvents` | `editable-events` | When true, events are editable. | `boolean` | `true` |
-| `hideNavigation` | `hide-navigation` | When disabled, the navigation toolbar won't be displayed. | `boolean` | `false` |
-| `viewType` | `view-type` | Type of the view. | `KupCalendarViewTypes.DAY \| KupCalendarViewTypes.LIST \| KupCalendarViewTypes.MONTH \| KupCalendarViewTypes.WEEK` | `KupCalendarViewTypes.MONTH` |
+| Property         | Attribute         | Description                                                                | Type                                                                                                               | Default                      |
+| ---------------- | ----------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `currentDate`    | `current-date`    | Sets the initial date of the calendar. Must be in ISO format (YYYY-MM-DD). | `string`                                                                                                           | `null`                       |
+| `customStyle`    | `custom-style`    | Custom style of the component.                                             | `string`                                                                                                           | `''`                         |
+| `data`           | --                | Actual data of the calendar.                                               | `KupCalendarData`                                                                                                  | `null`                       |
+| `editableEvents` | `editable-events` | When true, events are editable.                                            | `boolean`                                                                                                          | `true`                       |
+| `hideNavigation` | `hide-navigation` | When disabled, the navigation toolbar won't be displayed.                  | `boolean`                                                                                                          | `false`                      |
+| `viewType`       | `view-type`       | Type of the view.                                                          | `KupCalendarViewTypes.DAY \| KupCalendarViewTypes.LIST \| KupCalendarViewTypes.MONTH \| KupCalendarViewTypes.WEEK` | `KupCalendarViewTypes.MONTH` |
+
 
 ## Events
 
-| Event | Description | Type |
-| --- | --- | --- |
-| `kup-calendar-dateclick` | When a date is clicked. | `CustomEvent<KupCalendarDateClickEventPayload>` |
-| `kup-calendar-eventclick` | When an event is clicked. | `CustomEvent<KupCalendarEventClickEventPayload>` |
-| `kup-calendar-eventdrop` | When a date is dropped. | `CustomEvent<KupCalendarEventDropEventPayload>` |
+| Event                     | Description                | Type                                             |
+| ------------------------- | -------------------------- | ------------------------------------------------ |
+| `kup-calendar-dateclick`  | When a date is clicked.    | `CustomEvent<KupCalendarDateClickEventPayload>`  |
+| `kup-calendar-eventclick` | When an event is clicked.  | `CustomEvent<KupCalendarEventClickEventPayload>` |
+| `kup-calendar-eventdrop`  | When a date is dropped.    | `CustomEvent<KupCalendarEventDropEventPayload>`  |
 | `kup-calendar-viewchange` | When the navigation change | `CustomEvent<KupCalendarViewChangeEventPayload>` |
+
 
 ## Methods
 
@@ -30,8 +33,8 @@ Used to retrieve component's props values.
 
 #### Parameters
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name           | Type      | Description                                                                            |
+| -------------- | --------- | -------------------------------------------------------------------------------------- |
 | `descriptions` | `boolean` | - When provided and true, the result will be the list of props with their description. |
 
 #### Returns
@@ -48,6 +51,8 @@ This method is used to trigger a new render of the component.
 
 Type: `Promise<void>`
 
+
+
 ### `resizeCallback() => Promise<void>`
 
 This method is invoked by KupManager whenever the component changes size.
@@ -56,49 +61,54 @@ This method is invoked by KupManager whenever the component changes size.
 
 Type: `Promise<void>`
 
+
+
 ### `setProps(props: GenericObject) => Promise<void>`
 
 Sets the props to the component.
 
 #### Parameters
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name    | Type            | Description                                                  |
+| ------- | --------------- | ------------------------------------------------------------ |
 | `props` | `GenericObject` | - Object containing props that will be set to the component. |
 
 #### Returns
 
 Type: `Promise<void>`
 
+
+
+
 ## CSS Custom Properties
 
-| Name | Description |
-| --- | --- |
-| `--kup-calendar-background-color` | Background of the component. |
-| `--kup-calendar-border-color` | Sets borders color of the calendar. |
-| `--kup-calendar-event-background-color` | Sets background color of events. |
-| `--kup-calendar-event-border-color` | Sets border color of events. |
-| `--kup-calendar-event-border-radius` | Sets border radius of events. |
-| `--kup-calendar-event-color` | Sets text color of events. |
-| `--kup-calendar-font-family` | Sets the font family of the component. |
-| `--kup-calendar-font-size` | Sets the font size of the component. |
-| `--kup-calendar-header-background-color` | Sets background color of the header cell. |
-| `--kup-calendar-header-color` | Sets text color of the header cell. |
-| `--kup-calendar-navigator-border` | Sets the border of the navigator. |
+| Name                                          | Description                                         |
+| --------------------------------------------- | --------------------------------------------------- |
+| `--kup-calendar-background-color`             | Background of the component.                        |
+| `--kup-calendar-border-color`                 | Sets borders color of the calendar.                 |
+| `--kup-calendar-event-background-color`       | Sets background color of events.                    |
+| `--kup-calendar-event-border-color`           | Sets border color of events.                        |
+| `--kup-calendar-event-border-radius`          | Sets border radius of events.                       |
+| `--kup-calendar-event-color`                  | Sets text color of events.                          |
+| `--kup-calendar-font-family`                  | Sets the font family of the component.              |
+| `--kup-calendar-font-size`                    | Sets the font size of the component.                |
+| `--kup-calendar-header-background-color`      | Sets background color of the header cell.           |
+| `--kup-calendar-header-color`                 | Sets text color of the header cell.                 |
+| `--kup-calendar-navigator-border`             | Sets the border of the navigator.                   |
 | `--kup-calendar-no-work-day-background-color` | Sets background color of sunday and saturday cells. |
-| `--kup-calendar-no-work-day-color` | Sets text color of sunday and saturday cells. |
-| `--kup-calendar-today-background-color` | Sets background color of today's cell. |
+| `--kup-calendar-no-work-day-color`            | Sets text color of sunday and saturday cells.       |
+| `--kup-calendar-today-background-color`       | Sets background color of today's cell.              |
+
 
 ## Dependencies
 
 ### Depends on
 
--   [kup-card](../kup-card)
--   [kup-dialog](../kup-dialog)
--   [kup-badge](../kup-badge)
+- [kup-card](../kup-card)
+- [kup-dialog](../kup-dialog)
+- [kup-badge](../kup-badge)
 
 ### Graph
-
 ```mermaid
 graph TD;
   kup-calendar --> kup-card
@@ -260,6 +270,6 @@ graph TD;
   style kup-calendar fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
----
+----------------------------------------------
 
-_Built with [StencilJS](https://stenciljs.com/)_
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/ketchup/src/components/kup-cell/kup-cell-declarations.ts
+++ b/packages/ketchup/src/components/kup-cell/kup-cell-declarations.ts
@@ -8,3 +8,10 @@ export enum KupCellProps {
     density = "The density of the cell, defaults at 'dense' and can be also set to 'wide' or 'medium'.",
     dragEnabled = 'When set to true, the component is draggable.',
 }
+
+export enum KupCellSubmitButtonPosition {
+    top = 'column-reverse',
+    bottom = 'column',
+    left = 'row-reverse',
+    right = 'row',
+}

--- a/packages/ketchup/src/components/kup-cell/kup-cell-declarations.ts
+++ b/packages/ketchup/src/components/kup-cell/kup-cell-declarations.ts
@@ -1,3 +1,6 @@
+import { KupDataCell, KupEventPayload } from '../../components';
+import { KupDataCellOptions } from '../../managers/kup-data/kup-data-declarations';
+
 /**
  * Props of the kup-cell component.
  * Used to export every prop in an object.
@@ -14,4 +17,8 @@ export enum KupCellSubmitButtonPosition {
     bottom = 'column',
     left = 'row-reverse',
     right = 'row',
+}
+
+export interface KupCellSubmitClickEventPayload extends KupEventPayload {
+    cell: KupDataCellOptions;
 }

--- a/packages/ketchup/src/components/kup-cell/kup-cell.tsx
+++ b/packages/ketchup/src/components/kup-cell/kup-cell.tsx
@@ -4,6 +4,8 @@ import {
     forceUpdate,
     h,
     Host,
+    Event,
+    EventEmitter,
     Method,
     Prop,
 } from '@stencil/core';
@@ -17,6 +19,7 @@ import { componentWrapperId } from '../../variables/GenericVariables';
 import {
     KupCellProps,
     KupCellSubmitButtonPosition,
+    KupCellSubmitClickEventPayload,
 } from './kup-cell-declarations';
 import { FCell } from '../../f-components/f-cell/f-cell';
 import {
@@ -97,6 +100,14 @@ export class KupCell {
     /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
     /*-------------------------------------------------*/
+
+    @Event({
+        eventName: 'kup-cell-submit-click',
+        composed: true,
+        cancelable: false,
+        bubbles: true,
+    })
+    kupCellSubmitClick: EventEmitter<KupCellSubmitClickEventPayload>;
 
     /**
      * Adds the given CSS classes to the cell's data.
@@ -221,6 +232,15 @@ export class KupCell {
         return row;
     }
 
+    private submitClick(e: MouseEvent): void {
+        e.stopPropagation();
+        this.kupCellSubmitClick.emit({
+            comp: this,
+            id: this.rootElement.id,
+            cell: this.data as KupDataCellOptions,
+        });
+    }
+
     /*-------------------------------------------------*/
     /*          L i f e c y c l e   H o o k s          */
     /*-------------------------------------------------*/
@@ -260,7 +280,6 @@ export class KupCell {
             display: this.showSubmit ? 'flex' : 'block',
             'flex-direction': this.showSubmit ? this.submitPosition : '',
         };
-
         return (
             <Host>
                 <style>
@@ -277,6 +296,9 @@ export class KupCell {
                                 KupLanguageGeneric.CONFIRM
                             )}
                             wrapperClass="form__submit"
+                            onClick={(e) => {
+                                this.submitClick(e);
+                            }}
                         ></FButton>
                     ) : null}
                 </div>

--- a/packages/ketchup/src/components/kup-cell/kup-cell.tsx
+++ b/packages/ketchup/src/components/kup-cell/kup-cell.tsx
@@ -33,6 +33,7 @@ import {
     KupDataRow,
 } from '../../managers/kup-data/kup-data-declarations';
 import { FCellOptions } from '../../f-components/f-cell-options.tsx/f-cell-options';
+import { FButton } from '../../f-components/f-button/f-button';
 
 @Component({
     tag: 'kup-cell',
@@ -70,6 +71,11 @@ export class KupCell {
      */
     @Prop() dragEnabled: boolean = false;
 
+    /**
+     * Show submit button
+     */
+    @Prop() showSubmit: boolean = false;
+
     /*-------------------------------------------------*/
     /*       I n t e r n a l   V a r i a b l e s       */
     /*-------------------------------------------------*/
@@ -77,7 +83,7 @@ export class KupCell {
     /**
      * Instance of the KupManager class.
      */
-    private kupManager: KupManager = kupManagerInstance();
+    #kupManager: KupManager = kupManagerInstance();
 
     /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
@@ -165,7 +171,7 @@ export class KupCell {
                 };
             };
 
-            this.kupManager.interact.draggable(
+            this.#kupManager.interact.draggable(
                 this.rootElement.shadowRoot.querySelector(
                     '#' + componentWrapperId
                 ),
@@ -190,7 +196,7 @@ export class KupCell {
         const coltitle: string =
             this.data && this.data.obj && this.data.obj.t
                 ? this.data.obj.t + ';' + this.data.obj.p
-                : this.kupManager.language.translate(
+                : this.#kupManager.language.translate(
                       KupLanguageGeneric.EMPTY_OBJECT
                   );
         return {
@@ -211,23 +217,23 @@ export class KupCell {
     /*-------------------------------------------------*/
 
     componentWillLoad() {
-        this.kupManager.dates.register(this);
-        this.kupManager.debug.logLoad(this, false);
-        this.kupManager.language.register(this);
-        this.kupManager.theme.register(this);
+        this.#kupManager.dates.register(this);
+        this.#kupManager.debug.logLoad(this, false);
+        this.#kupManager.language.register(this);
+        this.#kupManager.theme.register(this);
     }
 
     componentDidLoad() {
-        this.kupManager.debug.logLoad(this, true);
+        this.#kupManager.debug.logLoad(this, true);
     }
 
     componentWillRender() {
-        this.kupManager.debug.logRender(this, false);
+        this.#kupManager.debug.logRender(this, false);
     }
 
     componentDidRender() {
         this.didRenderInteractables();
-        this.kupManager.debug.logRender(this, true);
+        this.#kupManager.debug.logRender(this, true);
     }
 
     render() {
@@ -240,23 +246,37 @@ export class KupCell {
             renderKup: true,
             row: this.generateRow(),
         };
+
+        const sectionStyle = {
+            display: this.showSubmit ? 'flex' : 'block',
+        };
+
         return (
             <Host>
                 <style>
-                    {this.kupManager.theme.setKupStyle(
+                    {this.#kupManager.theme.setKupStyle(
                         this.rootElement as KupComponent
                     )}
                 </style>
-                <div id={componentWrapperId}>
+                <div id={componentWrapperId} style={sectionStyle}>
                     <FCellOptions {...props}></FCellOptions>
+                    {this.showSubmit ? (
+                        <FButton
+                            buttonType="submit"
+                            label={this.#kupManager.language.translate(
+                                KupLanguageGeneric.CONFIRM
+                            )}
+                            wrapperClass="form__submit"
+                        ></FButton>
+                    ) : null}
                 </div>
             </Host>
         );
     }
 
     disconnectedCallback() {
-        this.kupManager.dates.unregister(this);
-        this.kupManager.language.unregister(this);
-        this.kupManager.theme.unregister(this);
+        this.#kupManager.dates.unregister(this);
+        this.#kupManager.language.unregister(this);
+        this.#kupManager.theme.unregister(this);
     }
 }

--- a/packages/ketchup/src/components/kup-cell/kup-cell.tsx
+++ b/packages/ketchup/src/components/kup-cell/kup-cell.tsx
@@ -14,7 +14,10 @@ import {
 import { GenericObject, KupComponent } from '../../types/GenericTypes';
 import { getProps, setProps } from '../../utils/utils';
 import { componentWrapperId } from '../../variables/GenericVariables';
-import { KupCellProps } from './kup-cell-declarations';
+import {
+    KupCellProps,
+    KupCellSubmitButtonPosition,
+} from './kup-cell-declarations';
 import { FCell } from '../../f-components/f-cell/f-cell';
 import {
     FCellOptionsProps,
@@ -75,6 +78,12 @@ export class KupCell {
      * Show submit button
      */
     @Prop() showSubmit: boolean = false;
+
+    /**
+     * Submit button position, default is right
+     */
+    @Prop() submitPosition: KupCellSubmitButtonPosition =
+        KupCellSubmitButtonPosition.right;
 
     /*-------------------------------------------------*/
     /*       I n t e r n a l   V a r i a b l e s       */
@@ -249,6 +258,7 @@ export class KupCell {
 
         const sectionStyle = {
             display: this.showSubmit ? 'flex' : 'block',
+            'flex-direction': this.showSubmit ? this.submitPosition : '',
         };
 
         return (

--- a/packages/ketchup/src/components/kup-cell/readme.md
+++ b/packages/ketchup/src/components/kup-cell/readme.md
@@ -5,12 +5,21 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                             | Type                                                                                  | Default             |
-| ------------- | -------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `customStyle` | `custom-style` | Custom style of the component.                                                          | `string`                                                                              | `''`                |
-| `data`        | --             | The data of the cell.                                                                   | `KupDataCell`                                                                         | `null`              |
-| `density`     | `density`      | The density of the cell, defaults at 'dense' and can be also set to 'wide' or 'medium'. | `FCellPadding.DENSE \| FCellPadding.MEDIUM \| FCellPadding.NONE \| FCellPadding.WIDE` | `FCellPadding.NONE` |
-| `dragEnabled` | `drag-enabled` | When set to true, the component is draggable.                                           | `boolean`                                                                             | `false`             |
+| Property         | Attribute         | Description                                                                             | Type                                                                                                                                             | Default                             |
+| ---------------- | ----------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| `customStyle`    | `custom-style`    | Custom style of the component.                                                          | `string`                                                                                                                                         | `''`                                |
+| `data`           | --                | The data of the cell.                                                                   | `KupDataCell`                                                                                                                                    | `null`                              |
+| `density`        | `density`         | The density of the cell, defaults at 'dense' and can be also set to 'wide' or 'medium'. | `FCellPadding.DENSE \| FCellPadding.MEDIUM \| FCellPadding.NONE \| FCellPadding.WIDE`                                                            | `FCellPadding.NONE`                 |
+| `dragEnabled`    | `drag-enabled`    | When set to true, the component is draggable.                                           | `boolean`                                                                                                                                        | `false`                             |
+| `showSubmit`     | `show-submit`     | Show submit button                                                                      | `boolean`                                                                                                                                        | `false`                             |
+| `submitPosition` | `submit-position` | Submit button position, default is right                                                | `KupCellSubmitButtonPosition.bottom \| KupCellSubmitButtonPosition.left \| KupCellSubmitButtonPosition.right \| KupCellSubmitButtonPosition.top` | `KupCellSubmitButtonPosition.right` |
+
+
+## Events
+
+| Event                   | Description | Type                                          |
+| ----------------------- | ----------- | --------------------------------------------- |
+| `kup-cell-submit-click` |             | `CustomEvent<KupCellSubmitClickEventPayload>` |
 
 
 ## Methods

--- a/packages/ketchup/src/f-components/f-cell-options.tsx/f-cell-options.tsx
+++ b/packages/ketchup/src/f-components/f-cell-options.tsx/f-cell-options.tsx
@@ -123,7 +123,6 @@ export const FCellOptions: FunctionalComponent<FCellOptionsProps> = (
             </div>
         );
     }
-    console.log('props', mappedProps);
     return <FCell {...mappedProps}></FCell>;
 };
 


### PR DESCRIPTION
Through showSubmit and submitPosition Props, cell can be rendered with an additional button.
Added also new Event "kup-cell-submit-click" to catch the click on this button and get the current cell.