### PR TITLE
feat / tab-bar flex

### DIFF
--- a/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.scss
+++ b/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.scss
@@ -160,6 +160,12 @@
       }
     }
 
+    @media screen and (min-width: 678px) {
+      .tab {
+        flex: none;
+      }
+    }
+
     .tab__content {
       position: relative;
       width: 100%;


### PR DESCRIPTION
do not flex tab on tablet/desktop size. It'll only flex on mobile