### PR TITLE
Fix/escape attribute

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -182,9 +182,6 @@ export class KupInputPanel {
     #cellTypeComponents: Map<FCellTypes, string> = new Map<FCellTypes, string>([
         [FCellTypes.DATE, 'kup-date-picker'],
         [FCellTypes.TIME, 'kup-time-picker'],
-        // [FCellTypes.COMBOBOX, 'kup-combobox'],
-        // [FCellTypes.EDITOR, 'kup-editor'],
-        // [FCellTypes.CHIP, 'kup-chip'],
     ]);
     #cellCustomRender: Map<
         FCellShapes,


### PR DESCRIPTION
- Fixed a problem with character '/' when assigned to querySelector that breaks the input panel