### PR TITLE
fix input panel layout: fit-content

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -9,7 +9,7 @@
 */
 
 :host {
-  --kup-f-cell_width: fit-content;
+  --kup-fcell-width: fit-content;
   --kup_input_panel_background_color: var(
     --kup-input-panel-background-color,
     var(--kup-layer-0)

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -39,7 +39,7 @@
     padding: var(--kup_input_panel_padding);
     position: relative;
     gap: 2rem;
-    width: var(--kup-f-cell_width);
+    // width: var(--kup-fcell_width);
 
     &__commands {
       display: flex;

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -9,6 +9,7 @@
 */
 
 :host {
+  --kup-f-cell_width: fit-content;
   --kup_input_panel_background_color: var(
     --kup-input-panel-background-color,
     var(--kup-layer-0)
@@ -38,6 +39,7 @@
     padding: var(--kup_input_panel_padding);
     position: relative;
     gap: 2rem;
+    width: var(--kup-f-cell_width);
 
     &__commands {
       display: flex;

--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -27,7 +27,7 @@
   font-family: var(--kup_cell_font_family);
   font-size: var(--kup_cell_font_size);
   min-height: 100%;
-  width: 100%;
+  width: if(var(--kup-f-cell_width) != null, var(--kup-f-cell_width), 100%);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -1,4 +1,5 @@
 .f-cell {
+  --kup_fcell_width: var(--kup-fcell-width, 100%);
   --kup_cell_background: var(--kup-cell-background);
   --kup_cell_font_family: var(--kup-cell-font-family);
   --kup_cell_font_family_monospace: var(
@@ -27,7 +28,7 @@
   font-family: var(--kup_cell_font_family);
   font-size: var(--kup_cell_font_size);
   min-height: 100%;
-  width: if(var(--kup-f-cell_width) != null, var(--kup-f-cell_width), 100%);
+  width: var(--kup_fcell_width);
   word-break: break-all;
   word-wrap: break-word;
 


### PR DESCRIPTION
Added css property to set width property for every cell to fit-content instead of 100% in input panel.