### PR TITLE
feat/ShowFullDescription prop added and managed

### DIFF
--- a/packages/ketchup-showcase/src/views/components/advanced/imagelist/examples/ImageListDemo.vue
+++ b/packages/ketchup-showcase/src/views/components/advanced/imagelist/examples/ImageListDemo.vue
@@ -82,6 +82,14 @@ export default {
           default: 'true',
           try: 'switch',
         },
+        {
+          prop: 'showFullDescription',
+          description:
+            'When enabled, image descriptions will always be displayed entirely and not cut or truncated.',
+          type: 'boolean',
+          default: 'false',
+          try: 'switch',
+        },
       ],
       demoMethods: [
         {

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -2788,6 +2788,11 @@ export namespace Components {
           * @param props - Object containing props that will be set to the component.
          */
         "setProps": (props: GenericObject) => Promise<void>;
+        /**
+          * When enabled images descriptions will be fully shown.
+          * @default toDecide
+         */
+        "showFullDescription": boolean;
         "stateId": string;
         "store": KupStore;
     }
@@ -8231,6 +8236,11 @@ declare namespace LocalJSX {
           * An array of integers containing the path to a selected child.\
          */
         "selectedNode"?: TreeNodePath;
+        /**
+          * When enabled images descriptions will be fully shown.
+          * @default toDecide
+         */
+        "showFullDescription"?: boolean;
         "stateId"?: string;
         "store"?: KupStore;
     }

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list-declarations.ts
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list-declarations.ts
@@ -16,6 +16,7 @@ export enum KupImageListProps {
     data = 'Actual data of the component',
     ripple = "When enabled displays Material's ripple effect on clicked items.",
     rows = 'Cam set a specific number of rows. It overwrite the columns flow into rows flow',
+    showFullDescription = 'When enabled, image descriptions will always be displayed entirely and not cut or truncated.',
 }
 
 export interface KupImageListEventPayload extends KupEventPayload {

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -139,6 +139,13 @@ export class KupImageList {
     @Prop() selectedNode: TreeNodePath = [];
     @Prop() stateId: string = '';
     @Prop() store: KupStore;
+
+    /**
+     * When enabled images descriptions will be fully shown.
+     * @default toDecide
+     */
+    @Prop() showFullDescription: boolean = false;
+
     /*-------------------------------------------------*/
     /*       I n t e r n a l   V a r i a b l e s       */
     /*-------------------------------------------------*/
@@ -262,7 +269,10 @@ export class KupImageList {
         };
 
         const image = <FImage {...props}></FImage>;
-        const label = <div class="image-list__label">{node.value}</div>;
+        const labelClass =
+            'image-list__label' +
+            (this.showFullDescription == true ? ' label-full-description' : '');
+        const label = <div class={labelClass}>{node.value}</div>;
 
         const hasExternalResource =
             props.resource.indexOf('.') > -1 ||
@@ -543,6 +553,10 @@ export class KupImageList {
             combinedGridStyle = { ...combinedGridStyle, ...gridRowsStyle };
         }
 
+        const imlClass =
+            'image-list' +
+            (this.showFullDescription ? ' full-description' : '');
+
         return (
             <Host>
                 <style>
@@ -601,7 +615,7 @@ export class KupImageList {
                             </div>
                         ) : null}
                     </div>
-                    <div class="image-list" style={combinedGridStyle}>
+                    <div class={imlClass} style={combinedGridStyle}>
                         {...this.#createList()}
                     </div>
                 </div>

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -142,7 +142,7 @@ export class KupImageList {
 
     /**
      * When enabled images descriptions will be fully shown.
-     * @default toDecide
+     * @default false
      */
     @Prop() showFullDescription: boolean = false;
 

--- a/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
+++ b/packages/ketchup/src/components/kup-image-list/kup-image-list.tsx
@@ -269,10 +269,7 @@ export class KupImageList {
         };
 
         const image = <FImage {...props}></FImage>;
-        const labelClass =
-            'image-list__label' +
-            (this.showFullDescription == true ? ' label-full-description' : '');
-        const label = <div class={labelClass}>{node.value}</div>;
+        const label = <div class="image-list__label">{node.value}</div>;
 
         const hasExternalResource =
             props.resource.indexOf('.') > -1 ||

--- a/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
+++ b/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
@@ -160,6 +160,10 @@
     }
   }
 
+  &.full-description .image-list__image {
+    display: flow-root;
+  }
+
   &__item {
     background-color: var(--kup_imagelist_item_background_color);
     border-radius: var(--kup_imagelist_item_border_radius);
@@ -193,6 +197,12 @@
     white-space: nowrap;
     padding: var(--kup-space-03);
     @include kup-label-01;
+    &.label-full-description {
+      overflow: unset;
+      text-align: center;
+      text-overflow: unset;
+      white-space: normal;
+    }
   }
 }
 

--- a/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
+++ b/packages/ketchup/src/components/kup-image-list/styles/kup-image-list-main.scss
@@ -133,6 +133,19 @@
   width: 100%;
   grid-auto-flow: row;
 
+  &.full-description {
+    .f-cell .f-cell__content .image-list__wrapper .f-image.image-list__image {
+      display: flow-root;
+    }
+    .image-list__label {
+      overflow: unset;
+      text-align: center;
+      text-overflow: unset;
+      white-space: normal;
+      overflow-wrap: break-word;
+    }
+  }
+
   .f-cell {
     height: 100%;
     width: 100%;
@@ -160,10 +173,6 @@
     }
   }
 
-  &.full-description .image-list__image {
-    display: flow-root;
-  }
-
   &__item {
     background-color: var(--kup_imagelist_item_background_color);
     border-radius: var(--kup_imagelist_item_border_radius);
@@ -184,7 +193,6 @@
     width: 100%;
     height: calc(100% - 16px - var(--kup-space-03) * 2);
     overflow: hidden;
-
     .f-image__icon {
       mask-size: 100% !important;
     }
@@ -197,12 +205,6 @@
     white-space: nowrap;
     padding: var(--kup-space-03);
     @include kup-label-01;
-    &.label-full-description {
-      overflow: unset;
-      text-align: center;
-      text-overflow: unset;
-      white-space: normal;
-    }
   }
 }
 


### PR DESCRIPTION
The new ShowFullDescription prop has the job of enabling the full display of every IML description.
This avoids the description being "cut", by displaying it on more than one row.

This props adds a class "full-description" to the main "image-list" class and everything is managed in SCSS 