### PR TITLE
fix/absolute pos INP not showing fields without width

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -654,17 +654,30 @@ export class KupInputPanel {
             );
         }
 
-        const width = `${getAbsoluteWidth(section.absoluteWidth)}px`;
-        const height = `${getAbsoluteHeight(section.absoluteHeight)}px`;
+        //If width is not specified the div in the return at the end can be removed
+        if (getAbsoluteWidth(section.absoluteWidth) == null) {
+            return content;
+        }
+
+        const width = `${
+            getAbsoluteWidth(section.absoluteWidth) != null
+                ? `${getAbsoluteWidth(section.absoluteWidth)}px`
+                : '100%'
+        }`;
+        const height = `${
+            getAbsoluteHeight(section.absoluteHeight) != null
+                ? `${getAbsoluteHeight(section.absoluteHeight)}px`
+                : '100%'
+        }`;
         const top = `${getAbsoluteTop(section.absoluteRow)}px`;
         const left = `${getAbsoluteLeft(section.absoluteColumn)}px`;
 
         const sectionStyle = {
-            position: 'absolute',
-            width,
+            position: 'relative',
+            width: width,
             'min-width': width,
             'max-width': width,
-            height,
+            height: height,
             'min-height': height,
             'max-height': height,
             top,

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -674,10 +674,10 @@ export class KupInputPanel {
 
         const sectionStyle = {
             position: 'relative',
-            width: width,
+            width,
             'min-width': width,
             'max-width': width,
-            height: height,
+            height,
             'min-height': height,
             'max-height': height,
             top,


### PR DESCRIPTION
When an INP had absolute field positioning (like in InputLegacy) and width was null the fields were hidden.
This happened because the returned div wrapping { content } could not size itself correctly without a default width.

Now if a width is found the "wrapper" div is returned with also the other attributes, if a width is not found the div is removed because it will only hide its contents.

Right now height is not relevant because of the 40ch passed as default to the "input-panel--absolute" class

