### PR TITLE
feat/vertical absolute height calculated

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -1,5 +1,5 @@
-const CHAR_WIDTH = 12;
-const ROW_HEIGHT = 22;
+export const CHAR_WIDTH = 12;
+export const ROW_HEIGHT = 22;
 
 export const getAbsoluteWidth = (length: number) => {
     if (length == 0) {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -110,8 +110,6 @@
     }
 
     &--absolute {
-      // TODO: calc the height dynamically
-      height: 40ch;
       justify-content: flex-end;
 
       .input-panel-label {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -76,6 +76,7 @@ import {
     getAbsoluteLeft,
     getAbsoluteTop,
     getAbsoluteWidth,
+    ROW_HEIGHT,
 } from './kup-input-panel-utils';
 
 const dom: KupDom = document.documentElement as KupDom;
@@ -346,6 +347,12 @@ export class KupInputPanel {
         } else {
             if (layout.absolute) {
                 rowContent = this.#renderAbsoluteLayout(inputPanelCell, layout);
+                const maxAbsoluteRow = Math.max(
+                    ...layout.sections.flatMap((sec) =>
+                        sec.content.map((cont) => cont.absoluteRow || 0)
+                    )
+                );
+                styleObj.height = `${maxAbsoluteRow * ROW_HEIGHT}px`;
             } else {
                 if (!layout.sectionsType) {
                     const hasDim = layout.sections.some((sec) => sec.dim);


### PR DESCRIPTION
Vertical height of an absolute pos inputPanel is now calculated using: (BIGGEST_ABSOLUTE_ROW * ROW_HEIGHT) allowing for a "dynamic" height managment.

The fastest way I found to achieve this was to map the sections contained in the layout and then nest another map for the objects in the section.content looking at absoluteRow, then picking the biggest one with Math.max()