### PR TITLE
Feat/useAs in visualization and row insert editableTable

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -954,6 +954,10 @@ export class KupDataTable {
      * contains the id greater value in #originalDataLoaded
      */
     #originalDataLoadedMaxId: number;
+    /**
+     * contains the id greater value in #originalDataLoaded
+     */
+    #insertedRowIds: string[] = [];
 
     /**
      * Reference to the working area of the table. This is the below-wrapper reference.
@@ -3582,6 +3586,22 @@ export class KupDataTable {
         }
     }
 
+    #setCellEditability(column: KupDataColumn, row: KupDataTableRow): boolean {
+        if (!this.#insertedRowIds.includes(row.id)) {
+            return column.useAs
+                ? column.useAs === 'Dec' || column.useAs === 'Key'
+                    ? false
+                    : true
+                : column.isEditable;
+        } else {
+            return column.useAs
+                ? column.useAs === 'Dec'
+                    ? false
+                    : true
+                : column.isEditable;
+        }
+    }
+
     //==== Fixed columns and rows methods ====
     #composeFixedCellStyleAndClass(
         columnCssIndex: number,
@@ -5263,8 +5283,8 @@ export class KupDataTable {
                         indend.push(<span class="indent" />);
                     }
                 }
-
                 const cell = row.cells[name] ? row.cells[name] : null;
+                cell.isEditable = this.#setCellEditability(currentColumn, row);
                 if (!cell) {
                     if (this.autoFillMissingCells) {
                         return <td data-column={name} data-row={row}></td>;
@@ -6072,6 +6092,8 @@ export class KupDataTable {
             newRow.id = (
                 this.#originalDataLoadedMaxId + ++this.#insertCount
             ).toString();
+
+            this.#insertedRowIds.push(newRow.id);
             this.insertNewRow(newRow, true);
         };
 
@@ -6084,11 +6106,11 @@ export class KupDataTable {
 
         const addConfirmButton = () => {
             this.#kupManager.keysBinding.register('enter', () => {
-                const bc = this.rootElement.shadowRoot.activeElement as HTMLInputElement;
+                const bc = this.rootElement.shadowRoot
+                    .activeElement as HTMLInputElement;
                 bc.blur();
-                this.#handleUpdateClick()
-        
-        });
+                this.#handleUpdateClick();
+            });
             commandButtons.push(
                 <kup-button
                     styling={styling}

--- a/packages/ketchup/src/managers/kup-data/kup-data-declarations.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data-declarations.ts
@@ -40,6 +40,7 @@ export interface KupDataColumn {
     cellData?: GenericObject;
     cellSlotData?: GenericObject;
     tooltip?: boolean;
+    useAs?: string;
 }
 export interface KupDataColumnChild {
     name: string;


### PR DESCRIPTION
Needs https://github.com/smeup/webup.js/pull/717 pr changes to be effective
Managed new attribute useAs for editable data-table.
The value is found in columns and it affects the cells under the column in 2 ways:
- useAs = "Dec" : the cell is never editable, in both row visualization and insert (usually this value is calcuated by backend)
- useAs = "Key" : cell is only editable when i'm adding a row to the table. If the row is in "visualization mode" the cell is not editable