### PR TITLE
f-autocomplete

### DIFF
--- a/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete-declarations.ts
+++ b/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete-declarations.ts
@@ -5,6 +5,6 @@ import { FTextFieldProps } from '../f-text-field/f-text-field-declarations';
  */
 export interface FAutocompleteProps extends FTextFieldProps {
     options: { label: string; value: string }[];
-    optionsVisible: boolean;
     minCharsForAutocomplete?: number;
+    onOptionClick: (value: string) => void;
 }

--- a/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete-declarations.ts
+++ b/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete-declarations.ts
@@ -1,0 +1,10 @@
+import type { FComponent, KupComponentSizing } from '../../types/GenericTypes';
+import { FTextFieldProps } from '../f-text-field/f-text-field-declarations';
+/**
+ * Props of the f-autocomplete component.
+ */
+export interface FAutocompleteProps extends FTextFieldProps {
+    options: { label: string; value: string }[];
+    optionsVisible: boolean;
+    minCharsForAutocomplete?: number;
+}

--- a/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.scss
+++ b/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.scss
@@ -1,0 +1,51 @@
+#kup-component {
+  --kup_autocomplete_item_height: var(--kup-textfield-medium-height, 40px);
+  --kup_autocomplete_medium_padding: var(
+    --kup-textfield-medium-padding,
+    0 var(--kup-space-05)
+  );
+  --kup_autocomplete_background_color: var(
+    --kup-textfield-background-color,
+    var(--kup-layer-1)
+  );
+  --kup_autocomplete_background_color_hover: var(
+    --kup-textfield-background-color-hover,
+    var(--kup-layer-1-hover)
+  );
+
+  .f-autocomplete {
+    position: relative;
+
+    &-list {
+      width: 100%;
+      height: 0;
+      max-height: calc(var(--kup_autocomplete_item_height) * 4);
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      opacity: 0;
+      transition: height 0.2s, opacity 0.2s;
+      overflow: hidden;
+
+      &--visible {
+        height: auto;
+        opacity: 1;
+        overflow: hidden auto;
+      }
+    }
+
+    &-list-item {
+      min-height: var(--kup_autocomplete_item_height);
+      display: flex;
+      align-items: center;
+      background-color: var(--kup_autocomplete_background_color);
+      padding: var(--kup_autocomplete_medium_padding);
+      cursor: pointer;
+
+      &:hover {
+        background-color: var(--kup_autocomplete_background_color_hover);
+      }
+    }
+  }
+}

--- a/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.tsx
+++ b/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.tsx
@@ -6,23 +6,31 @@ import { FTextField } from '../f-text-field/f-text-field';
 /*-------------------------------------------------*/
 /*                C o m p o n e n t                */
 /*-------------------------------------------------*/
+let timeout;
 
 export const FAutocomplete: FunctionalComponent<FAutocompleteProps> = (
     props: FAutocompleteProps
 ) => {
     const minCharsForOptions: number = props.minCharsForAutocomplete || 3;
-    const listIsShowed: boolean =
-        props.optionsVisible || props.value?.length >= minCharsForOptions;
 
     const listClass: Record<string, boolean> = {
         'f-autocomplete-list': true,
-        'f-autocomplete-list--visible': listIsShowed,
-        [`f-autocomplete-list--${props.sizing || 'small'}`]: true,
+    };
+
+    const handleOnInput = (event) => {
+        props.onInput(event);
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            showOptions({
+                event: event,
+                minChars: minCharsForOptions,
+            });
+        }, 400);
     };
 
     return (
         <div class="f-autocomplete">
-            <FTextField {...props} />
+            <FTextField {...props} onInput={handleOnInput} />
             <ul class={listClass}>
                 {props.options
                     .filter((option) =>
@@ -34,6 +42,9 @@ export const FAutocomplete: FunctionalComponent<FAutocompleteProps> = (
                         <li
                             key={`f-autocomplete-list-item-${index}-${option.value}`}
                             class="f-autocomplete-list-item"
+                            onClick={() => {
+                                props.onOptionClick(option.value);
+                            }}
                         >
                             {option.label}
                         </li>
@@ -46,3 +57,25 @@ export const FAutocomplete: FunctionalComponent<FAutocompleteProps> = (
 /*-------------------------------------------------*/
 /*                  M e t h o d s                  */
 /*-------------------------------------------------*/
+
+const showOptions = ({
+    event,
+    minChars,
+}: {
+    event: InputEvent;
+    minChars: number;
+}) => {
+    const element = event.target as HTMLInputElement;
+    const root = element.shadowRoot;
+
+    if (root) {
+        const input = root.querySelector('input');
+        const list = root.querySelector('.f-autocomplete-list');
+
+        if (input.value.length >= minChars) {
+            list.classList.add('f-autocomplete-list--visible');
+        } else {
+            list.classList.remove('f-autocomplete-list--visible');
+        }
+    }
+};

--- a/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.tsx
+++ b/packages/ketchup/src/f-components/f-autocomplete/f-autocomplete.tsx
@@ -1,0 +1,48 @@
+import { FunctionalComponent, VNode, h } from '@stencil/core';
+import { FAutocompleteProps } from './f-autocomplete-declarations';
+import { FTextFieldProps } from '../f-text-field/f-text-field-declarations';
+import { FTextField } from '../f-text-field/f-text-field';
+
+/*-------------------------------------------------*/
+/*                C o m p o n e n t                */
+/*-------------------------------------------------*/
+
+export const FAutocomplete: FunctionalComponent<FAutocompleteProps> = (
+    props: FAutocompleteProps
+) => {
+    const minCharsForOptions: number = props.minCharsForAutocomplete || 3;
+    const listIsShowed: boolean =
+        props.optionsVisible || props.value?.length >= minCharsForOptions;
+
+    const listClass: Record<string, boolean> = {
+        'f-autocomplete-list': true,
+        'f-autocomplete-list--visible': listIsShowed,
+        [`f-autocomplete-list--${props.sizing || 'small'}`]: true,
+    };
+
+    return (
+        <div class="f-autocomplete">
+            <FTextField {...props} />
+            <ul class={listClass}>
+                {props.options
+                    .filter((option) =>
+                        option.label
+                            .toLowerCase()
+                            .includes(props.value?.toLowerCase() ?? '')
+                    )
+                    .map((option, index) => (
+                        <li
+                            key={`f-autocomplete-list-item-${index}-${option.value}`}
+                            class="f-autocomplete-list-item"
+                        >
+                            {option.label}
+                        </li>
+                    ))}
+            </ul>
+        </div>
+    );
+};
+
+/*-------------------------------------------------*/
+/*                  M e t h o d s                  */
+/*-------------------------------------------------*/

--- a/packages/ketchup/src/managers/kup-theme/kup-theme-declarations.ts
+++ b/packages/ketchup/src/managers/kup-theme/kup-theme-declarations.ts
@@ -5,6 +5,10 @@ import { GenericObject, KupTagNames } from '../../types/GenericTypes';
  */
 export const masterCustomStyle = 'MASTER';
 /**
+ * Components using the FAutocomplete functional component.
+ */
+export const fAutocompleteUsers = [KupTagNames.CELL];
+/**
  * Components using the FButton functional component.
  */
 export const fButtonUsers = [

--- a/packages/ketchup/src/managers/kup-theme/kup-theme.ts
+++ b/packages/ketchup/src/managers/kup-theme/kup-theme.ts
@@ -8,6 +8,7 @@ import { getAssetPath } from '@stencil/core';
 import * as themesJson from './themes.json';
 import * as applicationCSS from './kup-theme-application.css';
 import * as componentCSS from './kup-theme-component.css';
+import * as fAutocompleteCSS from '../../f-components/f-autocomplete/f-autocomplete.css';
 import * as fButtonCSS from '../../f-components/f-button/f-button.css';
 import * as fCellCSS from '../../f-components/f-cell/f-cell.css';
 import * as fCheckboxCSS from '../../f-components/f-checkbox/f-checkbox.css';
@@ -23,6 +24,7 @@ import * as FTypographyCSS from '../../f-components/f-typography/f-typography.cs
 import * as rippleCSS from './mdc-ripple.css';
 import {
     editorUsers,
+    fAutocompleteUsers,
     fButtonUsers,
     fCellUsers,
     fCheckboxUsers,
@@ -266,6 +268,9 @@ export class KupTheme {
             completeStyle += ' ' + comp.customStyle;
         }
         if (tagName) {
+            if (fAutocompleteUsers.includes(tagName)) {
+                completeStyle += fAutocompleteCSS['default'];
+            }
             if (fButtonUsers.includes(tagName)) {
                 completeStyle += fButtonCSS['default'];
             }


### PR DESCRIPTION
A text input component with autocomplete functionality has been added, based on the f-text-field component.

Currently, the component meets the following requirements:

* **minCharsForAutcomplete**: Autocomplete options are displayed when the user enters at least 3 characters (default value). This behavior can be configured using the new minCharsForAutocomplete property.
* **Render delay**: Once the user enters the minimum number of characters, a setTimeout of 400 ms is executed, which renders the autocomplete options upon completion.
* **New onOptionClick event**: A new onOptionClick event has been added, returning the value of the selected option when clicked.
* **Built on f-text-field**: This component was developed by extending the functionality of the f-text-field component.


Note on the setTimeout implementation:

Since f-components are stateless, the rendering of autocomplete options is handled by accessing the shadowRoot of the kup-component containing the f-autocomplete component. The classes of the elements are then modified to manage their visibility and style.