### PR TITLE
Fix/CellEditability was overwritten by the ColumnEditability

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3586,18 +3586,26 @@ export class KupDataTable {
         }
     }
 
-    #setCellEditability(column: KupDataColumn, row: KupDataTableRow): boolean {
+    #setCellEditability(
+        column: KupDataColumn,
+        row: KupDataTableRow,
+        cell: KupDataTableCell
+    ): boolean {
         if (!this.#insertedRowIds.includes(row.id)) {
             return column.useAs
                 ? column.useAs === 'Dec' || column.useAs === 'Key'
                     ? false
                     : true
+                : cell.isEditable
+                ? cell.isEditable
                 : column.isEditable;
         } else {
             return column.useAs
                 ? column.useAs === 'Dec'
                     ? false
                     : true
+                : cell.isEditable
+                ? cell.isEditable
                 : column.isEditable;
         }
     }
@@ -5284,7 +5292,11 @@ export class KupDataTable {
                     }
                 }
                 const cell = row.cells[name] ? row.cells[name] : null;
-                cell.isEditable = this.#setCellEditability(currentColumn, row);
+                cell.isEditable = this.#setCellEditability(
+                    currentColumn,
+                    row,
+                    cell
+                );
                 if (!cell) {
                     if (this.autoFillMissingCells) {
                         return <td data-column={name} data-row={row}></td>;


### PR DESCRIPTION
Changes made to how the editability of a cell is assigned, now the priority is this:
1) useAs - only used for EXU
2) cell.isEditable - if useAs is missing, cell editability is not changed
3) column.isEditable - if for some reason, cell.isEditable and useAs are missing, editability is taken from the column