### PR TITLE
feat(kup-data-table): added retrieve last focused row

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -1551,6 +1551,10 @@ export namespace Components {
         "getCards": () => Promise<any>;
         "getInternalState": () => Promise<{ groups: GroupObject[]; filters: GenericFilter; data: KupDataTableDataset; }>;
         /**
+          * This method is used to retrieve last focused row or the first if there's no row focused
+         */
+        "getLastFocusedRow": () => Promise<KupDataTableRow>;
+        /**
           * Used to retrieve component's props values.
           * @param descriptions - When provided and true, the result will be the list of props with their description.
           * @returns List of props as object, each key will be a prop.

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -856,6 +856,7 @@ export class KupDataTable {
     decorateAndInitForUpdTable() {
         if (this.data['type'] === 'SmeupDataTable') {
             decorateDataTable(this.data);
+            this.#lastFocusedRow = this.data.rows[0];
         }
         if (this.updatableData) {
             this.#originalDataLoaded = JSON.parse(JSON.stringify(this.data));
@@ -1009,6 +1010,7 @@ export class KupDataTable {
     #columnDropCardAnchor: HTMLElement = null;
     #dropDownActionCardAnchor: HTMLElement = null;
     #insertCount = 0;
+    #lastFocusedRow: KupDataTableRow = null;
 
     #BUTTON_CANCEL_ID: string = 'cancel';
     #BUTTON_SUBMIT_ID: string = 'submit';
@@ -1699,6 +1701,13 @@ export class KupDataTable {
                 clickedRow: null,
             });
         }
+    }
+    /**
+     * This method is used to retrieve last focused row or the first if there's no row focused
+     */
+    @Method()
+    async getLastFocusedRow(): Promise<KupDataTableRow> {
+        return this.#lastFocusedRow;
     }
 
     #closeDropCard() {
@@ -3336,6 +3345,7 @@ export class KupDataTable {
                 this.#onRowClick(details.row, details.td, true);
                 return details;
             }
+            this.#lastFocusedRow = details.row;
         }
         return details;
     }

--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -228,6 +228,16 @@ Type: `Promise<{ groups: GroupObject[]; filters: GenericFilter; data: KupDataTab
 
 
 
+### `getLastFocusedRow() => Promise<KupDataTableRow>`
+
+This method is used to retrieve last focused row or the first if there's no row focused
+
+#### Returns
+
+Type: `Promise<KupDataTableRow>`
+
+
+
 ### `getProps(descriptions?: boolean) => Promise<GenericObject>`
 
 Used to retrieve component's props values.


### PR DESCRIPTION
added a new method to retrieve last focused row. 
If there's no row focused it will be the first row, otherwise it will be set in the `clickHandler` method.