### PR TITLE
timepicker prop manageSeconds to default: true

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -4242,7 +4242,7 @@ export namespace Components {
         "initialValue": string;
         /**
           * Manage seconds.
-          * @default false
+          * @default true
          */
         "manageSeconds": boolean;
         /**
@@ -9511,7 +9511,7 @@ declare namespace LocalJSX {
         "initialValue"?: string;
         /**
           * Manage seconds.
-          * @default false
+          * @default true
          */
         "manageSeconds"?: boolean;
         "onKup-timepicker-blur"?: (event: KupTimePickerCustomEvent<KupTimePickerEventPayload>) => void;

--- a/packages/ketchup/src/components/kup-time-picker/kup-time-picker.tsx
+++ b/packages/ketchup/src/components/kup-time-picker/kup-time-picker.tsx
@@ -89,9 +89,9 @@ export class KupTimePicker {
     @Prop() initialValue: string = '';
     /**
      * Manage seconds.
-     * @default false
+     * @default true
      */
-    @Prop() manageSeconds: boolean = false;
+    @Prop() manageSeconds: boolean = true;
     /**
      * Minutes step.
      * @default 10


### PR DESCRIPTION
Setting prop manageSeconds of timepicker always to true