### PR TITLE
bugfix: kup data table - new row id and diff

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
@@ -1125,14 +1125,14 @@ export function getDiffData(
     includesAlsoEmptyRows: boolean = false
 ): KupDataDataset {
     const diffDataTable = {
-        columns: modifiedData.columns,
+        columns: modifiedData.columns.filter((col) => col.visible),
         rows: [],
     };
 
     for (const modifiedRow of modifiedData.rows) {
         const newRow = { cells: {}, id: modifiedRow.id };
 
-        for (const column of modifiedData.columns) {
+        for (const column of diffDataTable.columns) {
             const cellKey = column.name;
             const modifiedCell = modifiedRow.cells[cellKey];
 
@@ -1143,7 +1143,10 @@ export function getDiffData(
                 ? originalRow.cells[cellKey]
                 : null;
 
-            if (!originalCell || modifiedCell.value !== originalCell.value) {
+            if (
+                (!originalCell && !!modifiedCell.value) ||
+                (originalCell && modifiedCell.value !== originalCell.value)
+            ) {
                 newRow.cells[cellKey] = modifiedCell;
             }
         }

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -847,7 +847,9 @@ export class KupDataTable {
 
     @Watch('data')
     identifyAndInitRows() {
-        identify(this.getRows());
+        if (this.data.rows.filter((r) => r.id == undefined).length) {
+            identify(this.getRows());
+        }
         this.expandGroupsHandler();
         this.#resetSelectedRows();
     }


### PR DESCRIPTION
In Updatable table return `after` with only set values, avoid invisible columns in diffs and add row id only if there's no id in at least one row.