### PR TITLE
Set error only if value is present in CMB/ACP shape

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1284,6 +1284,8 @@ export class KupInputPanel {
     ) {
         const configCMandACP = CMBandACPAdapter(currentValue, fieldLabel, []);
 
+        this.#setCellErrorIfValueIsPresent(currentValue, cell);
+
         if (cell.fun) {
             const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
 
@@ -1809,6 +1811,13 @@ export class KupInputPanel {
                 id
             );
         }
+    }
+
+    #setCellErrorIfValueIsPresent(
+        currentValue: string,
+        cell: KupInputPanelCell
+    ) {
+        cell.data.error = currentValue ? cell.data?.error : '';
     }
 
     #checkOnBlurEvent(cell: KupInputPanelCell, id: string) {


### PR DESCRIPTION
If error is not a mandatory type error, will be checked if currentValue is set in CMB/ACP shape.
If yes, the error sent by backend will be showed, else not.
This implementation has been done because even if an error is resolved in a CMB shape in INP component, error will always be sent inside data, even if it's resolved. 