### PR TITLE
Feat/INP label and ftextfield legacylook

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -123,6 +123,12 @@
       height: 100%;
       align-items: center;
       justify-content: center;
+
+      &--legacy-look {
+        font-size: 12px;
+        font-family: monospace;
+        white-space: pre;
+      }
     }
 
     &--absolute {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -126,7 +126,7 @@
 
       &--legacy-look {
         font-size: 12px;
-        font-family: monospace;
+        font-family: var(--kup-font-family-monospace);
         white-space: pre;
       }
     }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -615,9 +615,18 @@ export class KupInputPanel {
         );
     }
 
-    #renderLabel(cell: KupDataCell, cellId: string) {
+    #renderLabel(
+        cell: KupDataCell,
+        cellId: string,
+        isAbsoluteLayout?: boolean
+    ) {
         return (
-            <span class="input-panel-label" id={cellId}>
+            <span
+                class={`input-panel-label${
+                    isAbsoluteLayout ? ' input-panel-label--legacy-look' : ''
+                }`}
+                id={cellId}
+            >
                 {cell.value}
             </span>
         );
@@ -961,6 +970,7 @@ export class KupInputPanel {
             customStyle:
                 (fieldCell.cell.data.customStyle || '') +
                 '.mdc-text-field {height: unset !important;}',
+            legacyLook: true,
         };
 
         return (
@@ -2058,7 +2068,7 @@ export class KupInputPanel {
         this.#didLoadInteractables();
         this.kupReady.emit({ comp: this, id: this.rootElement.id });
         this.#kupManager.debug.logLoad(this, true);
-        if (this.#formRef && this.autoFocus){
+        if (this.#formRef && this.autoFocus) {
             this.#setFocusOnFirstInput();
         }
     }

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field-declarations.ts
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field-declarations.ts
@@ -26,6 +26,7 @@ export interface FTextFieldProps extends FComponent {
     isClearable?: boolean;
     label?: string;
     leadingLabel?: boolean;
+    legacyLook?: boolean;
     lightMode?: boolean;
     name?: string;
     placeholder?: string;

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -511,6 +511,13 @@
           top: 0;
         }
       }
+
+      &.mdc-text-field--legacy-look {
+        .mdc-text-field__input {
+          font-family: monospace;
+          font-size: 12px;
+        }
+      }
     }
 
     .mdc-error-icon,

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -514,7 +514,7 @@
 
       &.mdc-text-field--legacy-look {
         .mdc-text-field__input {
-          font-family: monospace;
+          font-family: var(--kup-font-family-monospace);
           font-size: 12px;
         }
       }

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -177,6 +177,7 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
         'mdc-text-field--with-quantity-buttons': props.quantityButtons,
         'mdc-text-field--error': Boolean(props.error),
         'mdc-text-field--alert': Boolean(props.alert),
+        'mdc-text-field--legacy-look': props.legacyLook,
         ...(!props.textArea && {
             [`mdc-text-field--${props.sizing || 'small'}`]: true,
         }),


### PR DESCRIPTION
Managed legacylook for FTextField and inp-label when layout is absolute.
Value passed in F-Cell data to avoid altering the Cell interface.
Added a class with "*prefix*--legacy-look" and then managed in the respective scss