### PR TITLE
fix/Inp absolute height considering table height

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -1,3 +1,5 @@
+import { KupInputPanelLayout } from './kup-input-panel-declarations';
+
 export const CHAR_WIDTH = 12;
 export const ROW_HEIGHT = 22;
 
@@ -39,4 +41,20 @@ export const getAbsoluteLeft = (col: number) => {
     }
 
     return col * CHAR_WIDTH;
+};
+
+export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
+    let inpRowHeight = 0;
+    layout.sections.forEach((section) => {
+        section.content.forEach((layoutField) => {
+            if (layoutField.absoluteRow > inpRowHeight) {
+                inpRowHeight =
+                    layoutField.absoluteRow +
+                    (layoutField.absoluteHeight > 1
+                        ? layoutField.absoluteHeight
+                        : 0);
+            }
+        });
+    });
+    return inpRowHeight;
 };

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -84,6 +84,7 @@ import {
     getAbsoluteLeft,
     getAbsoluteTop,
     getAbsoluteWidth,
+    getInpComponentAbsoluteHeight,
     ROW_HEIGHT,
 } from './kup-input-panel-utils';
 import { FTypography } from '../../f-components/f-typography/f-typography';
@@ -402,12 +403,9 @@ export class KupInputPanel {
         } else {
             if (layout.absolute) {
                 rowContent = this.#renderAbsoluteLayout(inputPanelCell, layout);
-                const maxAbsoluteRow = Math.max(
-                    ...layout.sections.flatMap((sec) =>
-                        sec.content.map((cont) => cont.absoluteRow || 0)
-                    )
-                );
-                styleObj.height = `${maxAbsoluteRow * ROW_HEIGHT}px`;
+                styleObj.height = `${
+                    getInpComponentAbsoluteHeight(layout) * ROW_HEIGHT
+                }px`;
             } else {
                 if (!layout.sectionsType) {
                     const hasDim = layout.sections.some((sec) => sec.dim);


### PR DESCRIPTION
When a table was put as the last row of an absolute INP it was cut .
That was because the absolute row was only the "start" of the table, without including its height, problem solved by adding such height (or absoluteHeight, if present) to the INP maxHeight calculations 