### PR TITLE
fix: legend and pie graph

### DIFF
--- a/packages/ketchup/src/components/kup-echart/kup-echart.tsx
+++ b/packages/ketchup/src/components/kup-echart/kup-echart.tsx
@@ -1265,7 +1265,6 @@ export class KupEchart {
                     type: 'pie',
                     data: data,
                     radius: '60%',
-                    stillShowZeroSum: false,
                     emphasis: {
                         itemStyle: {
                             shadowBlur: 10,


### PR DESCRIPTION
- Now when legend is placed top or bottom its orientation is horizontal, viceversa for right and left.
- When container size (width) is too small, legend is placed on the bottom side by default.
- Pie chart config and readability was improved: it does not show labels nor legend items when the value for an item equals 0.

https://youtu.be/1O-wDcUvoWs

