### PR TITLE
feat: add autocomplete props to customize suggestion

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -1847,6 +1847,11 @@ export namespace Components {
          */
         "initialValue": string;
         /**
+          * When enabled, font will be set to monospace and sizing will be extra-small .
+          * @default false
+         */
+        "legacyLook": boolean;
+        /**
           * When set to true, the component will be rendered as an outlined field.
           * @default false
          */
@@ -7596,6 +7601,11 @@ declare namespace LocalJSX {
           * @default ""
          */
         "initialValue"?: string;
+        /**
+          * When enabled, font will be set to monospace and sizing will be extra-small .
+          * @default false
+         */
+        "legacyLook"?: boolean;
         "onKup-datepicker-blur"?: (event: KupDatePickerCustomEvent<KupDatePickerEventPayload>) => void;
         "onKup-datepicker-change"?: (event: KupDatePickerCustomEvent<KupDatePickerEventPayload>) => void;
         "onKup-datepicker-cleariconclick"?: (event: KupDatePickerCustomEvent<KupEventPayload>) => void;

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field-declarations.ts
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field-declarations.ts
@@ -42,6 +42,7 @@ export interface FTextFieldProps extends FComponent {
     trailingLabel?: boolean;
     value?: string;
     showMarker?: boolean;
+    autocomplete?: string;
     onBlur?: (event: FocusEvent) => void;
     onClick?: (event: MouseEvent) => void;
     onChange?: (event: UIEvent) => void;

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -218,6 +218,7 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
                             disabled={props.disabled}
                             maxlength={props.maxLength}
                             value={value}
+                            autoComplete={props.autocomplete ?? 'off'}
                             onBlur={props.onBlur}
                             onClick={props.onClick}
                             onChange={props.onChange}
@@ -242,6 +243,7 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
                         maxlength={props.maxLength}
                         size={props.size}
                         value={value}
+                        autoComplete={props.autocomplete ?? 'off'}
                         onBlur={(e: FocusEvent) => {
                             if (persManageForNumberFormat) {
                                 const options: NumericFieldFormatOptions = {


### PR DESCRIPTION
Set the default `autocomplete: "off"` to disable suggestions