### PR TITLE
Fix/removing paginator and showing all rows in INL data table

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -947,6 +947,10 @@ export class KupInputPanel {
                 '.mdc-text-field {height: unset !important;}',
             legacyLook: true,
             helperEnabled: false,
+            ...(fieldCell.cell.shape === FCellShapes.TABLE && {
+                rowsPerPage: fieldCell.cell.data.data.rows.length,
+                showPaginator: false,
+            }),
         };
 
         return (


### PR DESCRIPTION
By adding rowsPerPage: (row number) and showPaginator: false the table paginator in an absoluteLayout inputPanel is removed and all rows are shown