### PR TITLE
fix: tooltip visible after dinamism

### DIFF
--- a/packages/ketchup/src/components/kup-echart/kup-echart.tsx
+++ b/packages/ketchup/src/components/kup-echart/kup-echart.tsx
@@ -1873,6 +1873,7 @@ export class KupEchart {
     }
 
     disconnectedCallback() {
+        this.#chartEl.dispose();
         this.#kupManager.theme.unregister(this);
         this.#kupManager.resize.unobserve(this.rootElement);
     }


### PR DESCRIPTION
Solves a problem with the tooltip still being visible after the execution of a Dynamism in webup.js.
We simply dispose the graph in unmount lifecycle hook.