### PR TITLE
fix: double vocodver in kup-data-table

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3478,18 +3478,16 @@ export class KupDataTable {
         return details;
     }
 
-    getVisibleColumnsWithCodVer(): Array<KupDataColumn> {
-        return this.getColumns().filter((col) => {
-
-            if (this.visibleColumns) {
-                return this.visibleColumns.includes(col.name);
-            } else {
-                return (!('visible' in col) || col.visible);
-            }
-        });
-    }
-
-    getVisibleColumns(): Array<KupDataColumn> {
+    getVisibleColumns(withCodVer = false): Array<KupDataColumn> {
+        if (withCodVer) {
+            return this.getColumns().filter((col) => {
+                if (this.visibleColumns) {
+                    return this.visibleColumns.includes(col.name);
+                } else {
+                    return !('visible' in col) || col.visible;
+                }
+            });
+        }
         // Starting columns filter
         let resultVisibleColumns = this.getColumns().filter((col) => {
             const isNotCodVer = !this.#kupManager.data.column.isCodVer(col);
@@ -5333,7 +5331,7 @@ export class KupDataTable {
                     const rowActions =
                         this.#kupManager.data.row.buildRowActions(
                             row,
-                            this.getVisibleColumnsWithCodVer(),
+                            this.getVisibleColumns(true),
                             this.rowActions,
                             this.commands ?? []
                         );

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3478,6 +3478,17 @@ export class KupDataTable {
         return details;
     }
 
+    getVisibleColumnsWithCodVer(): Array<KupDataColumn> {
+        return this.getColumns().filter((col) => {
+
+            if (this.visibleColumns) {
+                return this.visibleColumns.includes(col.name);
+            } else {
+                return (!('visible' in col) || col.visible);
+            }
+        });
+    }
+
     getVisibleColumns(): Array<KupDataColumn> {
         // Starting columns filter
         let resultVisibleColumns = this.getColumns().filter((col) => {
@@ -3485,7 +3496,7 @@ export class KupDataTable {
 
             if (this.visibleColumns) {
                 // if visible columns is specified, include only those columns
-                return this.visibleColumns.includes(col.name);
+                return isNotCodVer && this.visibleColumns.includes(col.name);
             } else {
                 return isNotCodVer && (!('visible' in col) || col.visible);
             }
@@ -5322,9 +5333,7 @@ export class KupDataTable {
                     const rowActions =
                         this.#kupManager.data.row.buildRowActions(
                             row,
-                            this.visibleColumns // To be fixed
-                                ? this.getVisibleColumns()
-                                : this.data.columns,
+                            this.getVisibleColumnsWithCodVer(),
                             this.rowActions,
                             this.commands ?? []
                         );

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3478,8 +3478,8 @@ export class KupDataTable {
         return details;
     }
 
-    getVisibleColumns(withCodVer = false): Array<KupDataColumn> {
-        if (withCodVer) {
+    getVisibleColumns({includeCodVer = false} = {}): Array<KupDataColumn> {
+        if (includeCodVer) {
             return this.getColumns().filter((col) => {
                 if (this.visibleColumns) {
                     return this.visibleColumns.includes(col.name);
@@ -5331,7 +5331,7 @@ export class KupDataTable {
                     const rowActions =
                         this.#kupManager.data.row.buildRowActions(
                             row,
-                            this.getVisibleColumns(true),
+                            this.getVisibleColumns({includeCodVer:true}),
                             this.rowActions,
                             this.commands ?? []
                         );


### PR DESCRIPTION
Managed the display of "codver" in the kup-data-table component, ensuring correct handling of its visibility both when the `visibleColumns` prop is provided and when it is not.