### PR TITLE
Fix/arrowDown error in combobox

### DIFF
--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -224,7 +224,7 @@ export class KupCombobox {
     })
     kupItemClick: EventEmitter<KupComboboxEventPayload>;
 
-    emitKupComboboxBlur() {
+    onKupBlur() {
         this.kupBlur.emit({
             comp: this,
             id: this.rootElement.id,
@@ -233,54 +233,15 @@ export class KupCombobox {
         });
     }
 
-    emitKupComboboxChange(ret) {
-        if (ret && ret.node) {
-            this.kupChange.emit({
-                comp: this,
-                id: this.rootElement.id,
-                value: this.value,
-                inputValue: this.#textfieldEl.value,
-                node: ret.node,
-            });
-        }
-    }
-
-    emitKupComboboxClick() {
-        this.kupClick.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-        });
-    }
-
-    emitKupComboboxIconClick() {
-        this.kupIconClick.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-            open: this.#textfieldWrapper.classList.contains('toggled'),
-        });
-    }
-
-    emitKupComboboxFocus() {
-        this.emitKupComboboxFocus();
-    }
-
-    emitKupComboboxInput(ret) {
-        if (ret && ret.node) {
-            this.emitKupComboboxInput(ret);
-        }
-    }
-
-    onKupBlur() {
-        this.emitKupComboboxBlur();
-    }
-
     onKupChange(value: string) {
         let ret = this.#consistencyCheck(value, undefined, true);
-        this.emitKupComboboxChange(ret);
+        this.kupChange.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+            node: ret.node,
+        });
     }
 
     onKupClick() {
@@ -291,21 +252,44 @@ export class KupCombobox {
                 this.#openList();
                 if (this.#componentTriggered == false) {
                     this.#componentTriggered = true;
-                    this.emitKupComboboxClick();
+                    this.kupClick.emit({
+                        comp: this,
+                        id: this.rootElement.id,
+                        value: this.value,
+                        inputValue: this.#textfieldEl.value,
+                    });
 
-                    this.emitKupComboboxIconClick();
+                    this.kupIconClick.emit({
+                        comp: this,
+                        id: this.rootElement.id,
+                        value: this.value,
+                        inputValue: this.#textfieldEl.value,
+                        open: this.#textfieldWrapper.classList.contains(
+                            'toggled'
+                        ),
+                    });
                 }
             }
         } else {
             if (this.#componentTriggered == false) {
                 this.#componentTriggered = true;
-                this.emitKupComboboxClick();
+                this.kupClick.emit({
+                    comp: this,
+                    id: this.rootElement.id,
+                    value: this.value,
+                    inputValue: this.#textfieldEl.value,
+                });
             }
         }
     }
 
     onKupFocus() {
-        this.emitKupComboboxFocus();
+        this.kupFocus.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+        });
     }
 
     onKupInput() {
@@ -315,7 +299,13 @@ export class KupCombobox {
             false
         );
         this.#openList();
-        this.emitKupComboboxInput(ret);
+        this.kupInput.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+            node: ret.node,
+        });
     }
 
     onKupIconClick() {
@@ -325,7 +315,13 @@ export class KupCombobox {
             this.#openList();
             if (this.#componentTriggered == false) {
                 this.#componentTriggered = true;
-                this.emitKupComboboxIconClick();
+                this.kupIconClick.emit({
+                    comp: this,
+                    id: this.rootElement.id,
+                    value: this.value,
+                    inputValue: this.#textfieldEl.value,
+                    open: this.#textfieldWrapper.classList.contains('toggled'),
+                });
             }
         }
     }

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -223,7 +223,7 @@ export class KupCombobox {
     })
     kupItemClick: EventEmitter<KupComboboxEventPayload>;
 
-    onKupBlur() {
+    emitKupComboboxBlur() {
         this.kupBlur.emit({
             comp: this,
             id: this.rootElement.id,
@@ -232,15 +232,65 @@ export class KupCombobox {
         });
     }
 
-    onKupChange(value: string) {
-        let ret = this.#consistencyCheck(value, undefined, true);
-        this.kupChange.emit({
+    emitKupComboboxChange(ret) {
+        if (ret && ret.node) {
+            this.kupChange.emit({
+                comp: this,
+                id: this.rootElement.id,
+                value: this.value,
+                inputValue: this.#textfieldEl.value,
+                node: ret.node,
+            });
+        }
+    }
+
+    emitKupComboboxClick() {
+        this.kupClick.emit({
             comp: this,
             id: this.rootElement.id,
             value: this.value,
             inputValue: this.#textfieldEl.value,
-            node: ret.node,
         });
+    }
+
+    emitKupComboboxIconClick() {
+        this.kupIconClick.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+            open: this.#textfieldWrapper.classList.contains('toggled'),
+        });
+    }
+
+    emitKupComboboxFocus() {
+        this.kupFocus.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+        });
+    }
+
+    emitKupComboboxInput(ret) {
+        if (ret && ret.node) {
+            this.kupInput.emit({
+                comp: this,
+                id: this.rootElement.id,
+                value: this.value,
+                inputValue: this.#textfieldEl.value,
+                node: ret.node,
+            });
+        }
+    }
+
+    onKupBlur() {
+        this.emitKupComboboxBlur();
+    }
+
+    onKupChange(value: string) {
+        let ret = this.#consistencyCheck(value, undefined, true);
+        this.emitKupComboboxChange(ret);
     }
 
     onKupClick() {
@@ -250,37 +300,15 @@ export class KupCombobox {
             } else {
                 this.#openList();
             }
-            this.kupClick.emit({
-                comp: this,
-                id: this.rootElement.id,
-                value: this.value,
-                inputValue: this.#textfieldEl.value,
-            });
-
-            this.kupIconClick.emit({
-                comp: this,
-                id: this.rootElement.id,
-                value: this.value,
-                inputValue: this.#textfieldEl.value,
-                open: this.#textfieldWrapper.classList.contains('toggled'),
-            });
+            this.emitKupComboboxClick();
+            this.emitKupComboboxIconClick();
         } else {
-            this.kupClick.emit({
-                comp: this,
-                id: this.rootElement.id,
-                value: this.value,
-                inputValue: this.#textfieldEl.value,
-            });
+            this.emitKupComboboxClick();
         }
     }
 
     onKupFocus() {
-        this.kupFocus.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-        });
+        this.emitKupComboboxFocus();
     }
 
     onKupInput() {
@@ -290,13 +318,7 @@ export class KupCombobox {
             false
         );
         this.#openList();
-        this.kupInput.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-            node: ret.node,
-        });
+        this.emitKupComboboxInput(ret);
     }
 
     onKupIconClick() {
@@ -305,13 +327,7 @@ export class KupCombobox {
         } else {
             this.#openList();
         }
-        this.kupIconClick.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-            open: this.#textfieldWrapper.classList.contains('toggled'),
-        });
+        this.emitKupComboboxIconClick();
     }
 
     onKupItemClick(e: CustomEvent<KupListEventPayload>) {
@@ -381,13 +397,13 @@ export class KupCombobox {
                 case 'ArrowDown':
                     e.preventDefault();
                     e.stopPropagation();
-                    this.#openList();
+                    this.onKupClick();
                     this.#listEl.focusNext();
                     break;
                 case 'ArrowUp':
                     e.preventDefault();
                     e.stopPropagation();
-                    this.#openList();
+                    this.onKupClick();
                     this.#listEl.focusPrevious();
                     break;
             }

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -229,7 +229,7 @@ export class KupList {
      */
     @Method()
     async focusNext(): Promise<void> {
-        if (this.#listItems.length !== 0) {
+        if (this.#listItems.length > 0) {
             if (
                 isNaN(this.focused) ||
                 this.focused === null ||
@@ -257,7 +257,7 @@ export class KupList {
      */
     @Method()
     async focusPrevious(): Promise<void> {
-        if (this.#listItems.length !== 0) {
+        if (this.#listItems.length > 0) {
             if (
                 isNaN(this.focused) ||
                 this.focused === null ||

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -229,52 +229,56 @@ export class KupList {
      */
     @Method()
     async focusNext(): Promise<void> {
-        if (
-            isNaN(this.focused) ||
-            this.focused === null ||
-            this.focused === undefined
-        ) {
-            if (this.selected.length === 1) {
-                const selectedItem: KupListNode = this.data.find(
-                    (x: KupListNode) => x.id === this.selected[0]
-                );
-                this.focused = this.data.indexOf(selectedItem) + 1;
+        if (this.#listItems.length !== 0) {
+            if (
+                isNaN(this.focused) ||
+                this.focused === null ||
+                this.focused === undefined
+            ) {
+                if (this.selected.length === 1) {
+                    const selectedItem: KupListNode = this.data.find(
+                        (x: KupListNode) => x.id === this.selected[0]
+                    );
+                    this.focused = this.data.indexOf(selectedItem) + 1;
+                } else {
+                    this.focused = 0;
+                }
             } else {
+                this.focused++;
+            }
+            if (this.focused > this.#listItems.length - 1) {
                 this.focused = 0;
             }
-        } else {
-            this.focused++;
+            this.#listItems[this.focused].focus();
         }
-        if (this.focused > this.#listItems.length - 1) {
-            this.focused = 0;
-        }
-        this.#listItems[this.focused].focus();
     }
     /**
      * Focuses the previous element of the list.
      */
     @Method()
     async focusPrevious(): Promise<void> {
-        if (
-            isNaN(this.focused) ||
-            this.focused === null ||
-            this.focused === undefined
-        ) {
-            if (this.selected.length === 1) {
-                const selectedItem: KupListNode = this.data.find(
-                    (x: KupListNode) => x.id === this.selected[0]
-                );
-                this.focused = this.data.indexOf(selectedItem) - 1;
+        if (this.#listItems.length !== 0) {
+            if (
+                isNaN(this.focused) ||
+                this.focused === null ||
+                this.focused === undefined
+            ) {
+                if (this.selected.length === 1) {
+                    const selectedItem: KupListNode = this.data.find(
+                        (x: KupListNode) => x.id === this.selected[0]
+                    );
+                    this.focused = this.data.indexOf(selectedItem) - 1;
+                } else {
+                    this.focused = 0;
+                }
             } else {
-                this.focused = 0;
+                this.focused--;
             }
-        } else {
-            this.focused--;
+            if (this.focused < 0) {
+                this.focused = this.#listItems.length - 1;
+            }
+            this.#listItems[this.focused].focus();
         }
-        if (this.focused < 0) {
-            this.focused = this.#listItems.length - 1;
-        }
-        this.#listItems[this.focused].focus();
     }
     /**
      * Used to retrieve component's props values.


### PR DESCRIPTION
Fixed an error occurring when arrowDown was pressed in a combobox with an empty list. Added an if checking for the list to be evaluated.

Now when arrowDown is pressed the methods called are the ones also called on click.
This change was made in order to correctly evaluate the list when arrowDown is pressed even after a "Tab" navigation and avoid empty lists