### PR TITLE
minor-fix/Fixed header in absolute INP data-table

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -967,6 +967,7 @@ export class KupInputPanel {
                 rowsPerPage: fieldCell.cell.data.data.rows.length,
                 showPaginator: false,
                 showFooter: false,
+                tableHeight: `${absoluteHeight}px`,
             }),
         };
 


### PR DESCRIPTION
By specifying tableHeight the table fixed headers are now active (if not the scroll was being done in the whole inp field and not only on the table)