### PR TITLE
fix/double arrowDown event in kup-list

### DIFF
--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -194,33 +194,6 @@ export class KupList {
     }
 
     /*-------------------------------------------------*/
-    /*                L i s t e n e r s                */
-    /*-------------------------------------------------*/
-
-    @Listen('keydown')
-    listenKeydown(e: KeyboardEvent) {
-        if (this.keyboardNavigation) {
-            switch (e.key) {
-                case 'ArrowDown':
-                    e.preventDefault();
-                    e.stopPropagation();
-                    this.focusNext();
-                    break;
-                case 'ArrowUp':
-                    e.preventDefault();
-                    e.stopPropagation();
-                    this.focusPrevious();
-                    break;
-                case 'Enter':
-                    e.preventDefault();
-                    e.stopPropagation();
-                    this.#handleSelection(this.focused);
-                    break;
-            }
-        }
-    }
-
-    /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
     /*-------------------------------------------------*/
 
@@ -249,7 +222,11 @@ export class KupList {
             if (this.focused > this.#listItems.length - 1) {
                 this.focused = 0;
             }
-            this.#listItems[this.focused].focus();
+            if (this.#listItems[this.focused]) {
+                this.#listItems[this.focused].focus();
+            } else if (this.#listItems[0]) {
+                this.#listItems.at(0).focus();
+            }
         }
     }
     /**
@@ -676,6 +653,17 @@ export class KupList {
             }, 0);
         }
         this.#kupManager.debug.logRender(this, true);
+        if (this.keyboardNavigation) {
+            this.#kupManager.keysBinding.register('ArrowDown', () => {
+                this.focusNext();
+            });
+            this.#kupManager.keysBinding.register('ArrowUp', () => {
+                this.focusPrevious();
+            });
+            this.#kupManager.keysBinding.register('Enter', () => {
+                this.#handleSelection(this.focused);
+            });
+        }
     }
 
     render() {
@@ -754,5 +742,10 @@ export class KupList {
 
     disconnectedCallback() {
         this.#kupManager.theme.unregister(this);
+        if (this.keyboardNavigation) {
+            this.#kupManager.keysBinding.unregister('ArrowDown');
+            this.#kupManager.keysBinding.unregister('ArrowUp');
+            this.#kupManager.keysBinding.unregister('Enter');
+        }
     }
 }

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -607,7 +607,6 @@ export class KupList {
     }
 
     #listenKeydown = (e: KeyboardEvent) => {
-        console.log('KeyDownList', e);
         if (this.keyboardNavigation) {
             switch (e.key) {
                 case 'ArrowDown':

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -222,11 +222,7 @@ export class KupList {
             if (this.focused > this.#listItems.length - 1) {
                 this.focused = 0;
             }
-            if (this.#listItems[this.focused]) {
-                this.#listItems[this.focused].focus();
-            } else if (this.#listItems[0]) {
-                this.#listItems.at(0).focus();
-            }
+            this.#listItems[this.focused].focus();
         }
     }
     /**
@@ -610,6 +606,29 @@ export class KupList {
         );
     }
 
+    #listenKeydown = (e: KeyboardEvent) => {
+        console.log('KeyDownList', e);
+        if (this.keyboardNavigation) {
+            switch (e.key) {
+                case 'ArrowDown':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this.focusNext();
+                    break;
+                case 'ArrowUp':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this.focusPrevious();
+                    break;
+                case 'Enter':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this.#handleSelection(this.focused);
+                    break;
+            }
+        }
+    };
+
     onFilterValueChange({ detail }) {
         let value = '';
         if (detail && detail.value) {
@@ -653,17 +672,6 @@ export class KupList {
             }, 0);
         }
         this.#kupManager.debug.logRender(this, true);
-        if (this.keyboardNavigation) {
-            this.#kupManager.keysBinding.register('ArrowDown', () => {
-                this.focusNext();
-            });
-            this.#kupManager.keysBinding.register('ArrowUp', () => {
-                this.focusPrevious();
-            });
-            this.#kupManager.keysBinding.register('Enter', () => {
-                this.#handleSelection(this.focused);
-            });
-        }
     }
 
     render() {
@@ -716,7 +724,11 @@ export class KupList {
                         this.rootElement as KupComponent
                     )}
                 </style>
-                <div id="kup-component" class={wrapperClass}>
+                <div
+                    id="kup-component"
+                    class={wrapperClass}
+                    onKeyDown={this.#listenKeydown}
+                >
                     {this.showFilter ? (
                         <div class={filterClass}>
                             {this.#createFilterComponent()}
@@ -742,10 +754,5 @@ export class KupList {
 
     disconnectedCallback() {
         this.#kupManager.theme.unregister(this);
-        if (this.keyboardNavigation) {
-            this.#kupManager.keysBinding.unregister('ArrowDown');
-            this.#kupManager.keysBinding.unregister('ArrowUp');
-            this.#kupManager.keysBinding.unregister('Enter');
-        }
     }
 }


### PR DESCRIPTION
ArrowDown and ArrowUp eventListener was attached twice to the window (and consequentially fired twice), a problem very likely due to Stencil's @Listen decorator.
The solution applied was to make the listenKeydown method (the one previously used in @Listen) as a private one and putting it in the onKeyDown attribute of the div with id="kup-component"