### PR TITLE
feat / manage ogg nr in label

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -143,6 +143,9 @@
 
       .input-panel-label {
         justify-content: start;
+        &.input-panel-label-number {
+          justify-content: end;
+        }
       }
 
       .mdc-text-field {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -626,13 +626,28 @@ export class KupInputPanel {
         cellId: string,
         isAbsoluteLayout?: boolean
     ) {
+        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+
+        const baseClass = 'input-panel-label';
+        const additionalClass = isAbsoluteLayout
+            ? ' input-panel-label--legacy-look'
+            : '';
+        const numberClass =
+            cellType === FCellTypes.NUMBER ? ' input-panel-label-number' : '';
+
+        if (cellType === FCellTypes.NUMBER) {
+            return (
+                <span
+                    class={`${baseClass}${additionalClass}${numberClass}`}
+                    id={cellId}
+                >
+                    {cell.value}
+                </span>
+            );
+        }
+
         return (
-            <span
-                class={`input-panel-label${
-                    isAbsoluteLayout ? ' input-panel-label--legacy-look' : ''
-                }`}
-                id={cellId}
-            >
+            <span class={`${baseClass}${additionalClass}`} id={cellId}>
                 {cell.value}
             </span>
         );


### PR DESCRIPTION
Manage inside the input panel the `number` ogg ( NR ) in non-editable mode. 
Whenever you rendere a LBL, and it's a number, the content is right-aligned   