### PR TITLE
Number in scientific notation

### DIFF
--- a/packages/ketchup/src/managers/kup-math/kup-math.ts
+++ b/packages/ketchup/src/managers/kup-math/kup-math.ts
@@ -463,7 +463,6 @@ export class KupMath {
         type: string,
         decSeparator?: string
     ): string {
-        console.log('number string to form', input);
         let value = this.numberToFormattedString(
             this.numberifySafe(input),
             decimals,

--- a/packages/ketchup/src/managers/kup-math/kup-math.ts
+++ b/packages/ketchup/src/managers/kup-math/kup-math.ts
@@ -268,6 +268,8 @@ export class KupMath {
             if (decFmt != '.') {
                 input = input.replace(getRegExpFromString(decFmt, 'g'), '.');
             }
+
+            input = Number(input);
         }
         let n = NaN;
 
@@ -461,6 +463,7 @@ export class KupMath {
         type: string,
         decSeparator?: string
     ): string {
+        console.log('number string to form', input);
         let value = this.numberToFormattedString(
             this.numberifySafe(input),
             decimals,


### PR DESCRIPTION
fixed a behavior when backend returns numbers in scientific notation (ex: from 1.132614403E7 to 11,326,144.03).
Now numbers of this type will be displayed correctly using Number() js constructor