### PR TITLE
fix/CMB and ACP focus and check fixes

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -268,7 +268,7 @@ export class KupAutocomplete {
 
     onKupChange(value: string) {
         this.#doConsistencyCheck = true;
-        const ret = this.#consistencyCheck(value, undefined);
+        const ret = this.#consistencyCheck(value, undefined, true);
         if (ret.exists || this.allowInconsistentValues) {
             this.kupChange.emit({
                 comp: this,
@@ -278,6 +278,7 @@ export class KupAutocomplete {
                 node: ret.node,
             });
         }
+        this.#closeList();
     }
 
     onKupClick() {
@@ -300,7 +301,11 @@ export class KupAutocomplete {
 
     onKupInput() {
         this.#doConsistencyCheck = true;
-        const ret = this.#consistencyCheck(this.#textfieldEl.value, undefined);
+        const ret = this.#consistencyCheck(
+            this.#textfieldEl.value,
+            undefined,
+            false
+        );
         setTimeout(() => {
             this.#openList(false);
             if (this.#textfieldEl.value.length >= this.minimumChars) {
@@ -447,7 +452,7 @@ export class KupAutocomplete {
     @Method()
     async setValue(value: string, valueDecode?: string) {
         this.#doConsistencyCheck = true;
-        this.#consistencyCheck(value, valueDecode);
+        this.#consistencyCheck(value, valueDecode, true);
     }
 
     /*-------------------------------------------------*/
@@ -508,14 +513,18 @@ export class KupAutocomplete {
         return this.#listEl.menuVisible == true;
     }
 
-    #consistencyCheck(idIn: string, idInDecode: string): ValueDisplayedValue {
+    #consistencyCheck(
+        idIn: string,
+        idInDecode: string,
+        eventShouldSetValue: boolean
+    ): ValueDisplayedValue {
         if (!this.#doConsistencyCheck) {
             return;
         }
         if (idIn && idInDecode) {
             this.displayedValue = this.displayedValue =
                 getIdOfItemByDisplayMode(
-                    { id: idIn, value: idInDecode ?? idIn },
+                    { id: idIn, value: idInDecode },
                     this.displayMode,
                     ' - '
                 );
@@ -528,7 +537,10 @@ export class KupAutocomplete {
                 this.selectMode,
                 this.displayMode
             );
-            if (ret.exists || this.allowInconsistentValues) {
+            if (
+                (ret.exists || this.allowInconsistentValues) &&
+                eventShouldSetValue
+            ) {
                 this.value = ret.value;
                 this.displayedValue = ret.displayedValue;
             } else {
@@ -573,7 +585,7 @@ export class KupAutocomplete {
     }
 
     componentDidLoad() {
-        this.#consistencyCheck(this.value, this.initialValueDecode);
+        this.#consistencyCheck(this.value, this.initialValueDecode, true);
         this.#kupManager.debug.logLoad(this, true);
     }
 

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -528,7 +528,6 @@ export class KupAutocomplete {
                 this.selectMode,
                 this.displayMode
             );
-            console.log('ret', ret);
             if (ret.exists || this.allowInconsistentValues) {
                 this.value = ret.value;
                 this.displayedValue = ret.displayedValue;

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -268,7 +268,7 @@ export class KupAutocomplete {
 
     onKupChange(value: string) {
         this.#doConsistencyCheck = true;
-        const ret = this.#consistencyCheck(value, undefined, true);
+        const ret = this.#consistencyCheck(value, undefined);
         if (ret.exists || this.allowInconsistentValues) {
             this.kupChange.emit({
                 comp: this,
@@ -300,11 +300,7 @@ export class KupAutocomplete {
 
     onKupInput() {
         this.#doConsistencyCheck = true;
-        const ret = this.#consistencyCheck(
-            this.#textfieldEl.value,
-            undefined,
-            false
-        );
+        const ret = this.#consistencyCheck(this.#textfieldEl.value, undefined);
         setTimeout(() => {
             this.#openList(false);
             if (this.#textfieldEl.value.length >= this.minimumChars) {
@@ -451,7 +447,7 @@ export class KupAutocomplete {
     @Method()
     async setValue(value: string, valueDecode?: string) {
         this.#doConsistencyCheck = true;
-        this.#consistencyCheck(value, valueDecode, true);
+        this.#consistencyCheck(value, valueDecode);
     }
 
     /*-------------------------------------------------*/
@@ -512,46 +508,38 @@ export class KupAutocomplete {
         return this.#listEl.menuVisible == true;
     }
 
-    #consistencyCheck(
-        idIn: string,
-        idInDecode: string,
-        setValue: boolean
-    ): ValueDisplayedValue {
+    #consistencyCheck(idIn: string, idInDecode: string): ValueDisplayedValue {
         if (!this.#doConsistencyCheck) {
             return;
         }
-        this.#doConsistencyCheck = false;
-        const ret = consistencyCheck(
-            idIn,
-            this.data['kup-list'],
-            this.#listEl,
-            this.selectMode,
-            this.displayMode
-        );
-        if (ret.exists || this.allowInconsistentValues) {
-            if (setValue) {
-                this.value = ret.value;
-                this.displayedValue = ret.displayedValue;
-            }
-            if (this.#listEl != null && !this.serverHandledFilter) {
-                this.#listEl.filter = ret.value;
-            }
-        } else {
-            if (setValue) {
-                this.displayedValue = getIdOfItemByDisplayMode(
+        if (idIn && idInDecode) {
+            this.displayedValue = this.displayedValue =
+                getIdOfItemByDisplayMode(
                     { id: idIn, value: idInDecode ?? idIn },
                     this.displayMode,
                     ' - '
                 );
+        } else {
+            this.#doConsistencyCheck = false;
+            const ret = consistencyCheck(
+                idIn,
+                this.data['kup-list'],
+                this.#listEl,
+                this.selectMode,
+                this.displayMode
+            );
+            console.log('ret', ret);
+            if (ret.exists || this.allowInconsistentValues) {
+                this.value = ret.value;
+                this.displayedValue = ret.displayedValue;
             } else {
                 this.displayedValue = idIn;
             }
             if (this.#listEl != null && !this.serverHandledFilter) {
                 this.#listEl.filter = ret.value;
             }
+            return ret;
         }
-
-        return ret;
     }
 
     #prepList() {
@@ -586,7 +574,7 @@ export class KupAutocomplete {
     }
 
     componentDidLoad() {
-        this.#consistencyCheck(this.value, this.initialValueDecode, true);
+        this.#consistencyCheck(this.value, this.initialValueDecode);
         this.#kupManager.debug.logLoad(this, true);
     }
 

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -234,7 +234,7 @@ export class KupCombobox {
     }
 
     onKupChange(value: string) {
-        let ret = this.#consistencyCheck(value, undefined);
+        let ret = this.#consistencyCheck(value, undefined, true);
         this.kupChange.emit({
             comp: this,
             id: this.rootElement.id,
@@ -242,6 +242,7 @@ export class KupCombobox {
             inputValue: this.#textfieldEl.value,
             node: ret.node,
         });
+        this.#closeList();
     }
 
     onKupClick() {
@@ -273,7 +274,11 @@ export class KupCombobox {
     }
 
     onKupInput() {
-        let ret = this.#consistencyCheck(this.#textfieldEl.value, undefined);
+        let ret = this.#consistencyCheck(
+            this.#textfieldEl.value,
+            undefined,
+            false
+        );
         this.#openList();
         this.kupInput.emit({
             comp: this,
@@ -413,7 +418,7 @@ export class KupCombobox {
      */
     @Method()
     async setValue(value: string, valueDecode?: string) {
-        this.#consistencyCheck(value, valueDecode);
+        this.#consistencyCheck(value, valueDecode, true);
     }
 
     /*-------------------------------------------------*/
@@ -471,14 +476,17 @@ export class KupCombobox {
         return this.#listEl.menuVisible == true;
     }
 
-    #consistencyCheck(idIn: string, idInDecode: string): ValueDisplayedValue {
+    #consistencyCheck(
+        idIn: string,
+        idInDecode: string,
+        eventShouldSetValue: boolean
+    ): ValueDisplayedValue {
         if (idIn && idInDecode) {
-            this.displayedValue = this.displayedValue =
-                getIdOfItemByDisplayMode(
-                    { id: idIn, value: idInDecode ?? idIn },
-                    this.displayMode,
-                    ' - '
-                );
+            this.displayedValue = getIdOfItemByDisplayMode(
+                { id: idIn, value: idInDecode },
+                this.displayMode,
+                ' - '
+            );
         } else {
             const ret = consistencyCheck(
                 idIn,
@@ -487,7 +495,7 @@ export class KupCombobox {
                 this.selectMode,
                 this.displayMode
             );
-            if (ret.exists) {
+            if (ret.exists && eventShouldSetValue) {
                 this.value = ret.value;
                 this.displayedValue = ret.displayedValue;
             } else {
@@ -534,7 +542,7 @@ export class KupCombobox {
     }
 
     componentDidLoad() {
-        this.#consistencyCheck(this.value, this.initialValueDecode);
+        this.#consistencyCheck(this.value, this.initialValueDecode, true);
         this.#kupManager.debug.logLoad(this, true);
     }
 

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -487,7 +487,6 @@ export class KupCombobox {
                 this.selectMode,
                 this.displayMode
             );
-            console.log('ret', ret);
             if (ret.exists) {
                 this.value = ret.value;
                 this.displayedValue = ret.displayedValue;

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -234,7 +234,7 @@ export class KupCombobox {
     }
 
     onKupChange(value: string) {
-        let ret = this.#consistencyCheck(value, undefined, true);
+        let ret = this.#consistencyCheck(value, undefined);
         this.kupChange.emit({
             comp: this,
             id: this.rootElement.id,
@@ -273,11 +273,7 @@ export class KupCombobox {
     }
 
     onKupInput() {
-        let ret = this.#consistencyCheck(
-            this.#textfieldEl.value,
-            undefined,
-            false
-        );
+        let ret = this.#consistencyCheck(this.#textfieldEl.value, undefined);
         this.#openList();
         this.kupInput.emit({
             comp: this,
@@ -417,7 +413,7 @@ export class KupCombobox {
      */
     @Method()
     async setValue(value: string, valueDecode?: string) {
-        this.#consistencyCheck(value, valueDecode, true);
+        this.#consistencyCheck(value, valueDecode);
     }
 
     /*-------------------------------------------------*/
@@ -475,44 +471,34 @@ export class KupCombobox {
         return this.#listEl.menuVisible == true;
     }
 
-    #consistencyCheck(
-        idIn: string,
-        idInDecode: string,
-        setValue: boolean
-    ): ValueDisplayedValue {
-        let ret = consistencyCheck(
-            idIn,
-            this.data['kup-list'],
-            this.#listEl,
-            this.selectMode,
-            this.displayMode
-        );
-
-        if (ret.exists) {
-            if (setValue) {
-                this.value = ret.value;
-                this.displayedValue = ret.displayedValue;
-            }
-            if (this.#listEl != null) {
-                this.#listEl.filter = ret.value;
-            }
-        } else {
-            this.value = idIn;
-            if (setValue) {
-                this.displayedValue = getIdOfItemByDisplayMode(
+    #consistencyCheck(idIn: string, idInDecode: string): ValueDisplayedValue {
+        if (idIn && idInDecode) {
+            this.displayedValue = this.displayedValue =
+                getIdOfItemByDisplayMode(
                     { id: idIn, value: idInDecode ?? idIn },
                     this.displayMode,
                     ' - '
                 );
+        } else {
+            const ret = consistencyCheck(
+                idIn,
+                this.data['kup-list'],
+                this.#listEl,
+                this.selectMode,
+                this.displayMode
+            );
+            console.log('ret', ret);
+            if (ret.exists) {
+                this.value = ret.value;
+                this.displayedValue = ret.displayedValue;
             } else {
                 this.displayedValue = idIn;
             }
             if (this.#listEl != null) {
                 this.#listEl.filter = ret.value;
             }
+            return ret;
         }
-
-        return ret;
     }
 
     #prepList() {
@@ -549,7 +535,7 @@ export class KupCombobox {
     }
 
     componentDidLoad() {
-        this.#consistencyCheck(this.value, this.initialValueDecode, true);
+        this.#consistencyCheck(this.value, this.initialValueDecode);
         this.#kupManager.debug.logLoad(this, true);
     }
 

--- a/packages/ketchup/src/components/kup-list/kup-list-helper.ts
+++ b/packages/ketchup/src/components/kup-list/kup-list-helper.ts
@@ -9,26 +9,28 @@ export function getIdOfItemByDisplayMode(
     mode: ItemsDisplayMode,
     separator: string
 ): string {
-    if (mode == ItemsDisplayMode.CODE) {
-        return item.id;
+    const { id, value } = item;
+
+    if (!id && value) {
+        return value;
     }
-    if (mode == ItemsDisplayMode.DESCRIPTION) {
-        return item.value;
+    if (id && !value) {
+        return id;
     }
-    if (
-        mode == ItemsDisplayMode.CODE_AND_DESC ||
-        mode == ItemsDisplayMode.CODE_AND_DESC_ALIAS
-    ) {
-        if (item.id || item.value) {
-            return item.id + separator + item.value;
-        }
+
+    switch (mode) {
+        case ItemsDisplayMode.CODE:
+            return id;
+        case ItemsDisplayMode.DESCRIPTION:
+            return value;
+        case ItemsDisplayMode.CODE_AND_DESC:
+        case ItemsDisplayMode.CODE_AND_DESC_ALIAS:
+            return id && value ? id + separator + value : id || value;
+        case ItemsDisplayMode.DESC_AND_CODE:
+            return value && id ? value + separator + id : value || id;
+        default:
+            return id;
     }
-    if (mode == ItemsDisplayMode.DESC_AND_CODE) {
-        if (item.id || item.value) {
-            return item.value + separator + item.id;
-        }
-    }
-    return item.id;
 }
 
 export function consistencyCheck(

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -146,6 +146,8 @@ export class KupList {
     #globalFilterTimeout: number;
     #radios: KupRadio[] = [];
     #listItems: HTMLElement[] = [];
+    #previouslySelectedItemIndex: number;
+    #previouslySelectedItemReached: boolean;
 
     /*-------------------------------------------------*/
     /*                   E v e n t s                   */
@@ -222,7 +224,16 @@ export class KupList {
             if (this.focused > this.#listItems.length - 1) {
                 this.focused = 0;
             }
-            this.#listItems[this.focused].focus();
+            if (
+                !this.#previouslySelectedItemReached &&
+                this.#listItems[this.#previouslySelectedItemIndex]
+            ) {
+                this.#previouslySelectedItemReached = true;
+                this.focused = this.#previouslySelectedItemIndex;
+                this.#listItems[this.#previouslySelectedItemIndex].focus();
+            } else if (this.#listItems[this.focused]) {
+                this.#listItems[this.focused].focus();
+            }
         }
     }
     /**
@@ -250,7 +261,16 @@ export class KupList {
             if (this.focused < 0) {
                 this.focused = this.#listItems.length - 1;
             }
-            this.#listItems[this.focused].focus();
+            if (
+                !this.#previouslySelectedItemReached &&
+                this.#listItems[this.#previouslySelectedItemIndex]
+            ) {
+                this.#previouslySelectedItemReached = true;
+                this.focused = this.#previouslySelectedItemIndex;
+                this.#listItems[this.#previouslySelectedItemIndex].focus();
+            } else if (this.#listItems[this.focused]) {
+                this.#listItems[this.focused].focus();
+            }
         }
     }
     /**
@@ -335,6 +355,8 @@ export class KupList {
                 item.selected = this.selected.includes(item.id);
             }
 
+            this.#previouslySelectedItemReached = false;
+            this.#previouslySelectedItemIndex = this.focused;
             this.kupClick.emit({
                 comp: this,
                 id: this.rootElement.id,
@@ -607,7 +629,7 @@ export class KupList {
     }
 
     #listenKeydown = (e: KeyboardEvent) => {
-        if (this.keyboardNavigation) {
+        if (this.keyboardNavigation && this.#listItems) {
             switch (e.key) {
                 case 'ArrowDown':
                     e.preventDefault();


### PR DESCRIPTION
Fixes list:
- kup-list issues with focusNext and focusPrevious methods generating an undefined exception when called with keyboard navigation.
- when opening a list from ACP and CMB when i press ArrowDown or ArrowUp to move focus from textField to kup-list the first focused element is the one previously selected by the user.
- optimized the Kup-List helper method with the task of creating the shown value based on the display mode
- fixed an error that occurred when typing an unexisting value in the acp. If i typed "hello" the shown value was "hello - hello", resulting in a confusing false decode, with this fix the value shown would be only "hello", without the "- hello" suffix