### PR TITLE
minor-fix/Autocomplete missed selection for list close

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -278,7 +278,6 @@ export class KupAutocomplete {
                 node: ret.node,
             });
         }
-        this.#closeList();
     }
 
     onKupClick() {


### PR DESCRIPTION
By closing the list directly in the kup-change the selection event didn't correctly select the list item clicked when the input value changed