### PR TITLE
 LS25000084 - fix: kup-input-panel display inline-flex

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -89,7 +89,7 @@
     }
 
     &__section-inline {
-      display: inline-block;
+      display: inline-flex;
       width: max-content;
     }
 


### PR DESCRIPTION
Change the CSS property from `inline-block` to `inline-flex` to properly validate the gap between elements.

![Screenshot 2025-01-10 alle 09 30 00](https://github.com/user-attachments/assets/cca9dfe1-6c92-4195-8dac-480313c22e85)
