### PR TITLE
minor-fix/TextField - Error outline over field focus outline

### DIFF
--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -252,6 +252,9 @@
 
       &.mdc-text-field--focused:not(.mdc-text-field--disabled) {
         outline: 2px solid var(--kup_textfield_outline_color);
+        &.mdc-text-field--error {
+          outline: 2px solid var(--kup-danger-color-60);
+        }
       }
 
       &.mdc-text-field--filled:not(.mdc-text-field--disabled)


### PR DESCRIPTION
In INL when a field was in error, the usual field error outline was "surpassed" by the field outline of the focus.
Now when the focus is set on a field in error, the border keeps the error outline