### PR TITLE
LS25000124/LS25000109: hide hidden columns in input panel only during render

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -434,9 +434,11 @@ export class KupInputPanel {
         let rowContent: VNode[];
 
         if (!layout?.sections?.length) {
-            rowContent = inputPanelCell.cells.map((cell) =>
-                this.#renderCell(cell.cell, inputPanelCell.row, cell.column)
-            );
+            rowContent = inputPanelCell.cells
+                .filter(({ column }) => column.visible)
+                .map((cell) =>
+                    this.#renderCell(cell.cell, inputPanelCell.row, cell.column)
+                );
         } else {
             if (layout.absolute) {
                 rowContent = this.#renderAbsoluteLayout(inputPanelCell, layout);
@@ -1062,20 +1064,18 @@ export class KupInputPanel {
         const layout = data?.rows[0]?.layout;
         const inpuPanelCells = data?.rows?.length
             ? data.rows.reduce((inpuPanelCells, row) => {
-                  const cells = data.columns
-                      .filter((column) => column.visible)
-                      .map((column) => {
-                          const cell = structuredClone(row.cells[column.name]);
-                          const mappedCell = cell
-                              ? {
-                                    ...cell,
-                                    data: this.#setData(cell, column, layout),
-                                    slotData: this.#slotData(cell, column),
-                                    isEditable: true,
-                                }
-                              : null;
-                          return { column, cell: mappedCell };
-                      });
+                  const cells = data.columns.map((column) => {
+                      const cell = structuredClone(row.cells[column.name]);
+                      const mappedCell = cell
+                          ? {
+                                ...cell,
+                                data: this.#setData(cell, column, layout),
+                                slotData: this.#slotData(cell, column),
+                                isEditable: true,
+                            }
+                          : null;
+                      return { column, cell: mappedCell };
+                  });
                   return [...inpuPanelCells, { cells, row }];
               }, [])
             : [];


### PR DESCRIPTION
hidden columns in input panel only during render, and not from after, to let use values of hidden columns, for example, in dynamic objects