### PR TITLE
LS25000055: allow empty strings in combo

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -533,12 +533,11 @@ export class KupAutocomplete {
             return;
         }
         if (idIn && idInDecode) {
-            this.displayedValue = this.displayedValue =
-                getIdOfItemByDisplayMode(
-                    { id: idIn, value: idInDecode },
-                    this.displayMode,
-                    ' - '
-                );
+            this.displayedValue = getIdOfItemByDisplayMode(
+                { id: idIn, value: idInDecode },
+                this.displayMode,
+                ' - '
+            );
         } else {
             this.#doConsistencyCheck = false;
             const ret = consistencyCheck(

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -481,7 +481,7 @@ export class KupCombobox {
         idInDecode: string,
         eventShouldSetValue: boolean
     ): ValueDisplayedValue {
-        if (idIn && idInDecode) {
+        if (idIn != null && idInDecode != null) {
             this.displayedValue = getIdOfItemByDisplayMode(
                 { id: idIn, value: idInDecode },
                 this.displayMode,

--- a/packages/ketchup/src/components/kup-list/kup-list-helper.ts
+++ b/packages/ketchup/src/components/kup-list/kup-list-helper.ts
@@ -11,10 +11,10 @@ export function getIdOfItemByDisplayMode(
 ): string {
     const { id, value } = item;
 
-    if (!id && value) {
+    if (id == null && value) {
         return value;
     }
-    if (id && !value) {
+    if (id && value == null) {
         return id;
     }
 


### PR DESCRIPTION
Before this pr using the checks used to verify the combo code or description existance were if(idIn) or if(!idIn), conditions that excluded the strings with a '' value or description (value/description used almost everywhere).

The fix was simply done by changing if conditions from thruthy or falsy checks to "!=null" and "==null" (doing it like this and not with !== or === includes both null and undefined in the checks)