### PR TITLE
LS25000013: fix: visible columns handling

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-state.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-state.ts
@@ -41,6 +41,7 @@ export class KupDataTableState implements KupState {
     showFooter: boolean = false;
     totals: TotalsMap;
     load: boolean = false;
+    visibleColumns: string[] = [];
 
     public toDebugString() {
         // TODO

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -231,6 +231,7 @@ export class KupDataTable {
                 this.dropEnabled = state.dropEnabled;
                 this.showFooter = state.showFooter;
                 this.totals = { ...state.totals };
+                this.visibleColumns = [...state.visibleColumns];
             }
         }
     }
@@ -507,6 +508,15 @@ export class KupDataTable {
                     },
                     ''
                 );
+                somethingChanged = true;
+            }
+            if (
+                !this.#kupManager.objects.deepEqual(
+                    this.state.visibleColumns,
+                    this.visibleColumns
+                )
+            ) {
+                this.state.visibleColumns = [...this.visibleColumns];
                 somethingChanged = true;
             }
 
@@ -1498,12 +1508,9 @@ export class KupDataTable {
     async hideColumn(column: KupDataColumn): Promise<void> {
         this.#kupManager.data.column.hide(this.data, [column.name]);
         if (this.visibleColumns?.length) {
-            const index = this.visibleColumns.findIndex(
-                (c) => c === column.name
+            this.visibleColumns = this.visibleColumns.filter(
+                (colName) => colName != column.name
             );
-            if (index) {
-                this.visibleColumns.splice(index, 1);
-            }
         }
         this.kupColumnRemove.emit({
             comp: this,


### PR DESCRIPTION
- Adds `visibleColumns` to `KupDataTableState` in order to preserve hidden and moved columns.
- Changes the way columns are hidden to tackle a problem that occurred when trying to remove a column name present more than once in `visibleColumns` string array.

https://youtu.be/u4ieVLH_nA4

Related to: https://github.com/smeup/webup.js/pull/1061