### PR TITLE
LS25000174: changed cellValue for disabled ACP and CMB

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -65,6 +65,7 @@ import {
     fullWidthFieldsComps,
     kupTypes,
 } from './f-cell-declarations';
+import { getIdOfItemByDisplayMode } from '../../components/kup-list/kup-list-helper';
 
 const dom: KupDom = document.documentElement as KupDom;
 
@@ -985,8 +986,11 @@ function setCell(
         case FCellTypes.DATETIME:
         case FCellTypes.TIME:
             if (content && content != '') {
-                const cellValue = getCellValueForDisplay(column, cell);
-                return <div class="f-cell__text">{cellValue}</div>;
+                return (
+                    <div class="f-cell__text">
+                        {adaptContentToDisplayMode(cell, content, ' - ')}
+                    </div>
+                );
             }
             return content;
         case FCellTypes.CHECKBOX:

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -982,15 +982,20 @@ function setCell(
     switch (cellType) {
         case FCellTypes.AUTOCOMPLETE:
         case FCellTypes.COMBOBOX:
-        case FCellTypes.DATE:
-        case FCellTypes.DATETIME:
-        case FCellTypes.TIME:
             if (content && content != '') {
                 return (
                     <div class="f-cell__text">
                         {adaptContentToDisplayMode(cell, content, ' - ')}
                     </div>
                 );
+            }
+            return content;
+        case FCellTypes.DATE:
+        case FCellTypes.DATETIME:
+        case FCellTypes.TIME:
+            if (content && content != '') {
+                const cellValue = getCellValueForDisplay(column, cell);
+                return <div class="f-cell__text">{cellValue}</div>;
             }
             return content;
         case FCellTypes.CHECKBOX:

--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -335,7 +335,10 @@ export function adaptContentToDisplayMode(
 
     const { k: code } = cell.obj;
     const desc = cell.decode;
-    const displayMode = cell.data?.displayMode;
+    const displayMode =
+        cell.data?.displayMode != null
+            ? cell.data?.displayMode
+            : ItemsDisplayMode.DESCRIPTION;
 
     const format = (a: string, b: string, sep: string = separator) =>
         a && b ? `${a} ${sep} ${b}` : '';


### PR DESCRIPTION
When an FCell of type ACP or CMB is disabled, instead of always displaying the code, it retrieves the value to display by looking at the display mode (keeping the DESCRIPTION as default when nothing is found).