### PR TITLE
feat / manage keyboard event

### DIFF
--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -354,6 +354,49 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
                             if (e.key.length > 1) {
                                 return;
                             }
+                            if (
+                                (e.key === '.' || e.key === ',') &&
+                                e.code === 'NumpadDecimal'
+                            ) {
+                                const inputElement =
+                                    e.target as HTMLInputElement;
+                                const cursorPosition =
+                                    inputElement.selectionStart ?? 0;
+
+                                // Ottieni il separatore decimale (in base alla configurazione)
+                                const decimalSeparator =
+                                    dom.ketchup.math.decimalSeparator();
+
+                                // Verifica se il valore contiene già il separatore decimale
+                                if (
+                                    inputElement.value.includes(
+                                        decimalSeparator
+                                    )
+                                ) {
+                                    // Se contiene già il separatore, non fare nulla e ritorna
+                                    e.preventDefault();
+                                    return;
+                                }
+
+                                // Inserisci il separatore decimale nel valore dell'input
+                                inputElement.value =
+                                    inputElement.value.slice(
+                                        0,
+                                        cursorPosition
+                                    ) +
+                                    decimalSeparator +
+                                    inputElement.value.slice(cursorPosition);
+
+                                // Posiziona il cursore dopo il separatore decimale
+                                inputElement.setSelectionRange(
+                                    cursorPosition + 1,
+                                    cursorPosition + 1
+                                );
+
+                                // Evita il comportamento predefinito
+                                e.preventDefault();
+                                return;
+                            }
 
                             const options: NumericFieldFormatOptions = {
                                 allowNegative: props.allowNegative ?? true,


### PR DESCRIPTION
- Identify the NumpadDecimal event
- If the value contain the separator it won't trigger the keyboard event
- Otherwise it'll include the decimalSeparator inside the input field.



_Another solution could have been swapping the numpadDecimals event with the corresponding decimalSeparator keyboard event but, at this time, it seems it doesn't work._