### PR TITLE
feat / kup neutral icons color

### DIFF
--- a/packages/ketchup/src/button.html
+++ b/packages/ketchup/src/button.html
@@ -109,6 +109,12 @@
             icon="favorite"
         ></kup-button>
         <kup-button
+            label="Flat"
+            class="kup-neutral"
+            styling="raised"
+            icon="favorite"
+        ></kup-button>
+        <kup-button
             label="Flat & Disabled"
             class="kup-neutral"
             styling="flat"

--- a/packages/ketchup/src/f-components/f-button/f-button.scss
+++ b/packages/ketchup/src/f-components/f-button/f-button.scss
@@ -483,6 +483,10 @@
       &.button--floating,
       &.button--raised {
         --kup_button_text_color: var(--kup-gray-color-0);
+        .f-image__icon,
+        .f-image__placeholder {
+          background-color: var(--kup-gray-color-0) !important;
+        }
 
         &:hover {
           --kup_button_background_color_hover: var(--kup-gray-color-80);


### PR DESCRIPTION
manage the color of the icon whenever the kup-neutral class is active.