### PR TITLE
LS25000015: Fix `f-checkbox` legacy look CSS

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -93,11 +93,6 @@
       width: max-content;
     }
 
-    .f-cell .f-checkbox .checkbox .checkbox__native-control {
-      height: 40px;
-      width: 40px;
-    }
-
     &__label_container {
       display: flex;
       flex-direction: column;

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -589,10 +589,7 @@ function setEditableCell(
                 classObj[FCellClasses.C_CENTERED] = true;
             }
 
-            if (
-                cell.shape === FCellShapes.INPUT_CHECKBOX ||
-                cell.data?.legacyLook
-            ) {
+            if (cell.shape === FCellShapes.INPUT_CHECKBOX) {
                 return (
                     <input
                         checked={

--- a/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
+++ b/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
@@ -25,7 +25,7 @@
     --kup-checkbox-text-disabled,
     var(--kup-text-disabled)
   );
-  --kup-checkbox-legacy-size: 15px;
+  --kup_checkbox_legacy_size: var(--kup-checkbox-legacy-size, 15px);
 
   @include kup-body-compact-01;
   display: flex;
@@ -220,13 +220,13 @@
 
   .checkbox--legacy-look {
     padding: 0;
-    height: var(--kup-checkbox-legacy-size);
-    width: var(--kup-checkbox-legacy-size);
+    height: var(--kup_checkbox_legacy_size);
+    width: var(--kup_checkbox_legacy_size);
 
     .checkbox__background,
     .checkbox__native-control {
-      height: var(--kup-checkbox-legacy-size);
-      width: var(--kup-checkbox-legacy-size);
+      height: var(--kup_checkbox_legacy_size);
+      width: var(--kup_checkbox_legacy_size);
     }
   }
 

--- a/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
+++ b/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
@@ -25,6 +25,7 @@
     --kup-checkbox-text-disabled,
     var(--kup-text-disabled)
   );
+  --kup-checkbox-legacy-size: 15px;
 
   @include kup-body-compact-01;
   display: flex;
@@ -219,9 +220,13 @@
 
   .checkbox--legacy-look {
     padding: 0;
+    height: var(--kup-checkbox-legacy-size);
+    width: var(--kup-checkbox-legacy-size);
+
+    .checkbox__background,
     .checkbox__native-control {
-      height: 18px;
-      width: 18px;
+      height: var(--kup-checkbox-legacy-size);
+      width: var(--kup-checkbox-legacy-size);
     }
   }
 


### PR DESCRIPTION
`f-checkbox` is now used on absolutely-positioned INP cell.