### PR TITLE
LS25000198: fix: datepicker overflow

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1016,7 +1016,7 @@ export class KupInputPanel {
                 absoluteLeft !== null
                     ? `${getAbsoluteLeft(field.absoluteColumn)}px`
                     : null,
-            overflow: 'auto',
+            overflow: 'hidden',
         };
 
         fieldCell.cell.data = {


### PR DESCRIPTION
Solves a problem with datepicker in `UP C5D` using option 02 to edit a record.

a pre existing branch on this, https://github.com/smeup/ketchup/tree/fix/kup-date-picker/fix-div , can be safely deleted cause proposed edits are wrong: the div has to exist in order to avoid [a problem](https://github.com/smeup/ketchup/pull/2390) with error message solved in the past.

https://youtu.be/BGYYIHMuXrU