### PR TITLE
feat / manage background in table

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
@@ -655,6 +655,7 @@ th.obj:hover span:not(.overlay-action) {
 }
 
 :host([legacy-look]) {
+  --kup-textfield-background-color: transparent;
   th .header-cell__content {
     font-family: var(--kup_datatable_font_family_monospace);
     white-space: pre !important;


### PR DESCRIPTION
Manage background error inside the `kup-data-table` component while legacy-look is true. This change will render a transparent background that will render the red background