### PR TITLE
fix/handled deletion of registered KeyboardEvents Input Panel

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -2124,6 +2124,10 @@ export class KupInputPanel {
     disconnectedCallback() {
         this.#kupManager.language.unregister(this);
         this.#kupManager.theme.unregister(this);
+
+        this.#keysShortcut.forEach((keyEvent) => {
+            this.#kupManager.keysBinding.unregister(keyEvent);
+        });
     }
     //#endregion
 }


### PR DESCRIPTION
The issue appeared while analyzing an INL that is closed by clicking the X button. It was discovered that the KeyboardEvents of the closed kup-input-panel remain active, and upon activation, they trigger inconsistent behaviors. With this fix, the events are removed when the component is destroyed.