### PR TITLE
Fix/kup date picker/fix div height

### DIFF
--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -667,27 +667,26 @@ export class KupDatePicker {
                         }
                         onInput={(e: InputEvent) => this.onKupInput(e)}
                     >
-                        <div id={this.rootElement.id + '_card'}>
-                            <kup-card
-                                ref={(el) => (this.pickerContainerEl = el)}
-                                data={cardData}
-                                layoutFamily={KupCardFamily.BUILT_IN}
-                                sizeX="300px"
-                                sizeY="auto"
-                                isMenu
-                                onkup-card-click={(
-                                    ev: CustomEvent<KupCardClickPayload>
-                                ) => {
-                                    if (
-                                        ev.detail.value != null &&
-                                        ev.detail.value != ''
-                                    )
-                                        this.onKupDatePickerItemClick(
-                                            ev.detail.value
-                                        );
-                                }}
-                            ></kup-card>
-                        </div>
+                        <kup-card
+                            ref={(el) => (this.pickerContainerEl = el)}
+                            data={cardData}
+                            layoutFamily={KupCardFamily.BUILT_IN}
+                            sizeX="300px"
+                            sizeY="auto"
+                            id={this.rootElement.id + '_card'}
+                            isMenu
+                            onkup-card-click={(
+                                ev: CustomEvent<KupCardClickPayload>
+                            ) => {
+                                if (
+                                    ev.detail.value != null &&
+                                    ev.detail.value != ''
+                                )
+                                    this.onKupDatePickerItemClick(
+                                        ev.detail.value
+                                    );
+                            }}
+                        ></kup-card>
                     </FTextField>
                 </div>
             </Host>

--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -4,14 +4,12 @@ import {
     Event,
     EventEmitter,
     forceUpdate,
-    Fragment,
     h,
     Host,
     Listen,
     Method,
     Prop,
     State,
-    VNode,
     Watch,
 } from '@stencil/core';
 import {
@@ -668,8 +666,10 @@ export class KupDatePicker {
                         }
                         onInput={(e: InputEvent) => this.onKupInput(e)}
                     >
-                        {/* <div id={this.rootElement.id + '_card'}> */}
-                        <Fragment>
+                        <div
+                            id={this.rootElement.id + '_card'}
+                            class="kup-date-picker-card"
+                        >
                             <kup-card
                                 ref={(el) => (this.pickerContainerEl = el)}
                                 data={cardData}
@@ -677,7 +677,6 @@ export class KupDatePicker {
                                 sizeX="300px"
                                 sizeY="auto"
                                 isMenu
-                                id={this.rootElement.id + '_card'}
                                 onkup-card-click={(
                                     ev: CustomEvent<KupCardClickPayload>
                                 ) => {
@@ -690,8 +689,7 @@ export class KupDatePicker {
                                         );
                                 }}
                             ></kup-card>
-                        </Fragment>
-                        {/* </div> */}
+                        </div>
                     </FTextField>
                 </div>
             </Host>

--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -4,6 +4,7 @@ import {
     Event,
     EventEmitter,
     forceUpdate,
+    Fragment,
     h,
     Host,
     Listen,
@@ -667,26 +668,30 @@ export class KupDatePicker {
                         }
                         onInput={(e: InputEvent) => this.onKupInput(e)}
                     >
-                        <kup-card
-                            ref={(el) => (this.pickerContainerEl = el)}
-                            data={cardData}
-                            layoutFamily={KupCardFamily.BUILT_IN}
-                            sizeX="300px"
-                            sizeY="auto"
-                            id={this.rootElement.id + '_card'}
-                            isMenu
-                            onkup-card-click={(
-                                ev: CustomEvent<KupCardClickPayload>
-                            ) => {
-                                if (
-                                    ev.detail.value != null &&
-                                    ev.detail.value != ''
-                                )
-                                    this.onKupDatePickerItemClick(
-                                        ev.detail.value
-                                    );
-                            }}
-                        ></kup-card>
+                        {/* <div id={this.rootElement.id + '_card'}> */}
+                        <Fragment>
+                            <kup-card
+                                ref={(el) => (this.pickerContainerEl = el)}
+                                data={cardData}
+                                layoutFamily={KupCardFamily.BUILT_IN}
+                                sizeX="300px"
+                                sizeY="auto"
+                                isMenu
+                                id={this.rootElement.id + '_card'}
+                                onkup-card-click={(
+                                    ev: CustomEvent<KupCardClickPayload>
+                                ) => {
+                                    if (
+                                        ev.detail.value != null &&
+                                        ev.detail.value != ''
+                                    )
+                                        this.onKupDatePickerItemClick(
+                                            ev.detail.value
+                                        );
+                                }}
+                            ></kup-card>
+                        </Fragment>
+                        {/* </div> */}
                     </FTextField>
                 </div>
             </Host>

--- a/packages/ketchup/src/components/kup-date-picker/styles/kup-date-picker-main.scss
+++ b/packages/ketchup/src/components/kup-date-picker/styles/kup-date-picker-main.scss
@@ -6,3 +6,7 @@
 .f-text-field {
   position: relative;
 }
+
+.kup-date-picker-card {
+  display: none;
+}


### PR DESCRIPTION
This fix is related to the `kup-date-picker` component.
Due to the new introduced div `id="_card"`, it will render a gap of 4px also between the input and the card ( which is the visual date selector ) while the card is not. 