### PR TITLE
LS25000233: fix: acp dynamic size

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -643,7 +643,7 @@ export class KupAutocomplete {
                 : false,
             showMarker: this.showMarker,
             ...(this.displayedValue && {
-                size: this.displayedValue.length + 5,
+                size: this.displayedValue.length,
             }),
         };
         const fullHeight =

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -642,6 +642,9 @@ export class KupAutocomplete {
                 ? true
                 : false,
             showMarker: this.showMarker,
+            ...(this.displayedValue && {
+                size: this.displayedValue.length + 5,
+            }),
         };
         const fullHeight =
             this.rootElement.classList.contains('kup-full-height');


### PR DESCRIPTION
Conditionally adds a prop to FTextFieldProps in `kup-autocomplete` to adapt the size of the input based on the current displayedValue

LS25000233 - Acp non adatta la dim nel caso di codice+descr