### PR TITLE
LS25000015: Fix checbox scroll for Chrome (Windows)

### DIFF
--- a/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
+++ b/packages/ketchup/src/f-components/f-checkbox/f-checkbox.scss
@@ -220,6 +220,7 @@
 
   .checkbox--legacy-look {
     padding: 0;
+    flex: 0;
     height: var(--kup_checkbox_legacy_size);
     width: var(--kup_checkbox_legacy_size);
 


### PR DESCRIPTION
Fix for https://github.com/smeup/ketchup/pull/2405 which has not taken into account Chrome browser for Windows.