### PR TITLE
LS25000069: Fix COD_VER double scrollbar

### DIFF
--- a/packages/ketchup/src/components/kup-card/standard/kup-card-standard-17.scss
+++ b/packages/ketchup/src/components/kup-card/standard/kup-card-standard-17.scss
@@ -21,6 +21,5 @@
     flex-direction: column;
     min-width: 16rem;
     overflow-y: auto;
-    max-height: 16rem;
   }
 }


### PR DESCRIPTION
With the max height set in that way if the card contained a scrollable list (like in the case of a VO;COD_VER) two scrollbars were generated, one caused by the list's max height, the other by the card's max height (scroll-list class)