### PR TITLE
LS25000375: ACP and CMB blurEvent only when list is closed

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -258,12 +258,14 @@ export class KupAutocomplete {
     kupItemClick: EventEmitter<KupAutocompleteEventPayload>;
 
     onKupBlur() {
-        this.kupBlur.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-        });
+        if (!this.#isListOpened()) {
+            this.kupBlur.emit({
+                comp: this,
+                id: this.rootElement.id,
+                value: this.value,
+                inputValue: this.#textfieldEl.value,
+            });
+        }
     }
 
     onKupChange(value: string) {

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -225,12 +225,14 @@ export class KupCombobox {
     kupItemClick: EventEmitter<KupComboboxEventPayload>;
 
     onKupBlur() {
-        this.kupBlur.emit({
-            comp: this,
-            id: this.rootElement.id,
-            value: this.value,
-            inputValue: this.#textfieldEl.value,
-        });
+        if (!this.#isListOpened()) {
+            this.kupBlur.emit({
+                comp: this,
+                id: this.rootElement.id,
+                value: this.value,
+                inputValue: this.#textfieldEl.value,
+            });
+        }
     }
 
     onKupChange(value: string) {


### PR DESCRIPTION
This PR solves a problem with CMB and ACP that occurs when their list is opened for the second time.

This happened because both ACP and CMB are not a single component, but the union of kup-list and f-text-field, so when the focus went from f-text-field to kup-list the blur event was triggered, the check was triggered, and the component refreshed (closing the list and forcing the user to re-close and re-open the list to properly select again).

The simplest solution found was to trigger the blur (and consequently the *CHECK) only when the list is actually closed

Issue where the problem was described
https://github.com/smeup/ketchup/issues/2368