### PR TITLE
LS25000332: feat: datatable performances cell action

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3023,7 +3023,8 @@ export class KupDataTable {
         this.rootElement.shadowRoot.append(this.#actionsCard);
         this.#kupManager.dynamicPosition.register(
             this.#actionsCard,
-            this.#dropDownActionCardAnchor as KupDynamicPositionAnchor,
+            this.#dropDownActionCardAnchor
+                .parentElement as KupDynamicPositionAnchor,
             0,
             KupDynamicPositionPlacement.AUTO,
             true

--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -36,25 +36,18 @@
     max-height: 100%;
   }
 
-  &:hover {
-    .f-image.f-cell__iconfunction.right,
-    .f-image.f-cell__iconfunction.left {
-      opacity: 1;
-      background-color: var(--kup-gray-color-10-hover);
-      z-index: 2;
-    }
-  }
   .f-cell__content {
     align-items: center;
     display: flex;
     width: 100%;
     position: relative;
 
-    .f-image.f-cell__iconfunction {
+    .f-cell__iconfunction {
       display: block;
-      opacity: 0;
       position: absolute;
       transition: opacity 0.3s ease;
+      background-color: var(--kup-gray-color-10-hover);
+      z-index: 2;
 
       &.right {
         right: 0;
@@ -62,10 +55,6 @@
 
       &.left {
         left: 0;
-      }
-
-      &:focus-within {
-        opacity: 1;
       }
     }
     img,

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -208,6 +208,7 @@ export const FCell: FunctionalComponent<FCellProps> = (
         };
         infoEl = <FImage {...fProps} />;
     }
+
     return (
         <div
             onKeyUp={(e) => cellEvent(e, props, cellType, FCellEvents.KEYUP)}
@@ -222,25 +223,54 @@ export const FCell: FunctionalComponent<FCellProps> = (
                 class="f-cell__content"
                 style={cell.styleContent}
                 title={cellTitle}
+                onMouseEnter={(e) => handleMouseEnter(e, props, cellType)}
+                onMouseLeave={(e) => handleMouseLeave(e)}
             >
-                {props.cellActionIcon && (
-                    <FImage
-                        resource="more_vert"
-                        sizeX="16px"
-                        sizeY="16px"
-                        wrapperClass={`f-cell__iconfunction ${
-                            cellType === FCellTypes.NUMBER ? 'left' : 'right'
-                        }`}
-                        onClick={props.cellActionIcon.onClick}
-                        tabIndex={0}
-                    />
-                )}
                 {children && children.length > 0
                     ? children
                     : [props.indents, infoEl, icon, content]}
             </div>
         </div>
     );
+};
+
+const handleMouseEnter = (
+    e: MouseEvent,
+    props: FCellProps,
+    cellType: FCellTypes
+) => {
+    if (props.cellActionIcon) {
+        const parent = e.currentTarget as HTMLElement;
+        const iconContainer = parent.querySelector('kup-image');
+
+        if (iconContainer) {
+            iconContainer.style.opacity = '1';
+            return;
+        }
+
+        const iconElement = document.createElement('kup-image');
+        iconElement.resource = 'more_vert';
+        iconElement.sizeX = '16px';
+        iconElement.sizeY = '16px';
+        iconElement.tabIndex = 0;
+        iconElement.className = `f-cell__iconfunction ${
+            cellType === FCellTypes.NUMBER ? 'left' : 'right'
+        }`;
+
+        if (props.cellActionIcon?.onClick) {
+            iconElement.addEventListener('click', props.cellActionIcon.onClick);
+        }
+        parent.appendChild(iconElement);
+    }
+};
+
+const handleMouseLeave = (event: MouseEvent) => {
+    const parent = event.currentTarget as HTMLElement;
+    const iconContainer = parent.querySelector('kup-image');
+
+    if (iconContainer) {
+        iconContainer.style.opacity = '0';
+    }
 };
 
 const mapData = (cell: KupDataCellOptions, column: KupDataColumn) => {

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -241,13 +241,6 @@ const handleMouseEnter = (
 ) => {
     if (props.cellActionIcon) {
         const parent = e.currentTarget as HTMLElement;
-        const iconContainer = parent.querySelector('kup-image');
-
-        if (iconContainer) {
-            iconContainer.style.opacity = '1';
-            return;
-        }
-
         const iconElement = document.createElement('kup-image');
         iconElement.resource = 'more_vert';
         iconElement.sizeX = '16px';
@@ -269,7 +262,7 @@ const handleMouseLeave = (event: MouseEvent) => {
     const iconContainer = parent.querySelector('kup-image');
 
     if (iconContainer) {
-        iconContainer.style.opacity = '0';
+        iconContainer.remove();
     }
 };
 


### PR DESCRIPTION
Adds a couple event handlers to `#f-cell__content` div in `f-cell` to add a clickable image only onMouseEnter.
This is done manually creating elements due to Stencil limitations in 
- using a State in Functional Components
- creating Node instances from VNode instances returned from h() function when trying to use `FImage`

Any suggestions on how to improve this handling?

`kup-image` is removed as mouse leaves the cell.
`kup-card` rendered on click is now anchored to `kup-image` parent element to preserve its dynamic positioning.

SAL video 1: https://youtu.be/7uvi3Qq4HG4
