### PR TITLE
LS24005508: feat: improve datatable filters

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -1831,6 +1831,11 @@ export namespace Components {
     }
     interface KupDatePicker {
         /**
+          * When set to true, the selected date will be appended to the current value instead of replacing it.
+          * @default false
+         */
+        "appendSelection": boolean;
+        /**
           * Custom style of the component.
           * @default ""
           * @see https://smeup.github.io/ketchup/#/customization
@@ -7577,6 +7582,11 @@ declare namespace LocalJSX {
         "visibleColumns"?: string[];
     }
     interface KupDatePicker {
+        /**
+          * When set to true, the selected date will be appended to the current value instead of replacing it.
+          * @default false
+         */
+        "appendSelection"?: boolean;
         /**
           * Custom style of the component.
           * @default ""

--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -40,6 +40,7 @@ import {
     KupCardFamily,
 } from '../kup-card/kup-card-declarations';
 import { getProps } from '../../utils/utils';
+import { FILTER_ANALIZER } from '../../utils/filters/filters-declarations';
 
 @Component({
     tag: 'kup-date-picker',
@@ -413,7 +414,10 @@ export class KupDatePicker {
                 this.ISOvalue = eventDetailValue;
                 this.notISOvalue = '';
             }
-        } else if (this.isAlphanumeric(eventDetailValue)) {
+        } else if (
+            this.isAlphanumeric(eventDetailValue) ||
+            eventDetailValue.match(FILTER_ANALIZER)
+        ) {
             /** donothing */
         } else if (
             this.kupManager.dates.isValidFormattedStringDate(eventDetailValue)
@@ -652,7 +656,7 @@ export class KupDatePicker {
                         disabled={this.disabled}
                         fullHeight={fullHeight}
                         fullWidth={fullWidth}
-                        maxLength={10}
+                        maxLength={textfieldData.maxLength ?? 10}
                         id={this.rootElement.id + '_text-field'}
                         value={this.getDateForOutput()}
                         onBlur={() => this.onKupBlur()}

--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -63,6 +63,12 @@ export class KupDatePicker {
     /*-------------------------------------------------*/
 
     /**
+     * When set to true, the selected date will be appended to the current value
+     * instead of replacing it.
+     * @default false
+     */
+    @Prop() appendSelection: boolean = false;
+    /**
      * Custom style of the component.
      * @default ""
      * @see https://smeup.github.io/ketchup/#/customization
@@ -404,35 +410,42 @@ export class KupDatePicker {
         isOnInputEvent?: boolean
     ) {
         let newValue = eventDetailValue;
-        this.ISOvalue = '';
         this.notISOvalue = newValue;
-        // check if input contains special codes
-        if (!eventDetailValue) {
-            /** donothing */
-        } else if (this.kupManager.dates.isIsoDate(eventDetailValue)) {
-            if (isOnInputEvent != true) {
-                this.ISOvalue = eventDetailValue;
-                this.notISOvalue = '';
+        this.ISOvalue = '';
+
+        if (eventDetailValue) {
+            const isValidFilter =
+                this.isAlphanumeric(eventDetailValue) ||
+                eventDetailValue.match(FILTER_ANALIZER);
+
+            if (this.kupManager.dates.isIsoDate(eventDetailValue)) {
+                if (!isOnInputEvent) {
+                    this.ISOvalue = eventDetailValue;
+                    if (!this.appendSelection) {
+                        this.notISOvalue = '';
+                    }
+                }
+            } else if (
+                !isValidFilter &&
+                this.kupManager.dates.isValidFormattedStringDate(
+                    eventDetailValue
+                )
+            ) {
+                if (!this.appendSelection) {
+                    newValue = this.kupManager.dates.format(
+                        this.kupManager.dates.normalize(eventDetailValue),
+                        KupDatesFormats.ISO_DATE
+                    );
+                    this.refreshPickerComponentValue(newValue);
+                }
+
+                if (!isOnInputEvent) {
+                    this.ISOvalue = newValue;
+                    if (!this.appendSelection) {
+                        this.notISOvalue = '';
+                    }
+                }
             }
-        } else if (
-            this.isAlphanumeric(eventDetailValue) ||
-            eventDetailValue.match(FILTER_ANALIZER)
-        ) {
-            /** donothing */
-        } else if (
-            this.kupManager.dates.isValidFormattedStringDate(eventDetailValue)
-        ) {
-            newValue = this.kupManager.dates.format(
-                this.kupManager.dates.normalize(eventDetailValue),
-                KupDatesFormats.ISO_DATE
-            );
-            this.refreshPickerComponentValue(newValue);
-            if (isOnInputEvent != true) {
-                this.ISOvalue = newValue;
-                this.notISOvalue = '';
-            }
-        } else {
-            /** donothing */
         }
 
         if (newValue != null && eventToRaise) {
@@ -469,7 +482,17 @@ export class KupDatePicker {
         if (newValue == null) {
             return;
         }
-        this.setValue(newValue);
+
+        if (this.appendSelection) {
+            // Append behavior: combine current value with the new date
+            const currentValue = this.textfieldEl.value;
+            const formattedDate = this.kupManager.dates.format(newValue);
+            const combinedValue = currentValue + formattedDate;
+            this.refreshPickerValue(combinedValue, undefined);
+        } else {
+            // Default behavior: replace the entire value
+            this.setValue(newValue);
+        }
     }
 
     getPickerValueSelected(): string {

--- a/packages/ketchup/src/utils/filters/filters-column-menu.ts
+++ b/packages/ketchup/src/utils/filters/filters-column-menu.ts
@@ -444,28 +444,6 @@ export class FiltersColumnMenu extends Filters {
             this.getTextFilterValueTmp(filters, column),
             false
         );
-        this._setIntervalTextFieldFilterValue(
-            filters,
-            column,
-            this.getIntervalTextFieldFilterValueTmp(
-                filters,
-                column,
-                FilterInterval.FROM
-            ),
-            FilterInterval.FROM,
-            false
-        );
-        this._setIntervalTextFieldFilterValue(
-            filters,
-            column,
-            this.getIntervalTextFieldFilterValueTmp(
-                filters,
-                column,
-                FilterInterval.TO
-            ),
-            FilterInterval.TO,
-            false
-        );
     }
 
     resetTextualFilters(filters: GenericFilter = {}, column: string) {
@@ -473,28 +451,6 @@ export class FiltersColumnMenu extends Filters {
             filters,
             column,
             this.getTextFilterValue(filters, column),
-            true
-        );
-        this._setIntervalTextFieldFilterValue(
-            filters,
-            column,
-            this.getIntervalTextFieldFilterValue(
-                filters,
-                column,
-                FilterInterval.FROM
-            ),
-            FilterInterval.FROM,
-            true
-        );
-        this._setIntervalTextFieldFilterValue(
-            filters,
-            column,
-            this.getIntervalTextFieldFilterValue(
-                filters,
-                column,
-                FilterInterval.TO
-            ),
-            FilterInterval.TO,
             true
         );
     }

--- a/packages/ketchup/src/utils/filters/filters-column-menu.ts
+++ b/packages/ketchup/src/utils/filters/filters-column-menu.ts
@@ -3,7 +3,6 @@ import { getValueForDisplay, getValueForDisplay2 } from '../cell-utils';
 import { Filters } from './filters';
 import {
     Filter,
-    FilterInterval,
     GenericFilter,
     ValueDisplayedValue,
 } from './filters-declarations';

--- a/packages/ketchup/src/utils/filters/filters-column-menu.ts
+++ b/packages/ketchup/src/utils/filters/filters-column-menu.ts
@@ -96,9 +96,6 @@ export class FiltersColumnMenu extends Filters {
         if (textfield != null && textfield.trim() != '') {
             return true;
         }
-        if (this._hasIntervalTextFieldFilterValues(filters, column, tmp)) {
-            return true;
-        }
         let checkboxes = this.getCheckBoxFilterValues(filters, column.name);
         if (checkboxes == null || checkboxes.length < 1) {
             return false;
@@ -129,57 +126,7 @@ export class FiltersColumnMenu extends Filters {
         values = filter.checkBoxes;
         return values;
     }
-    /**
-     * Returns whether a text field should be a date or time picker.
-     * @param {GenericFilter} filters - Filters of the component.
-     * @param {KupDataColumn} column - Name of the column.
-     * @returns {boolean} True when the text field is a date or time picker.
-     */
-    hasIntervalTextFieldFilterValues(
-        filters: GenericFilter = {},
-        column: KupDataColumn
-    ): boolean {
-        return this._hasIntervalTextFieldFilterValues(filters, column, false);
-    }
 
-    hasIntervalTextFieldFilterValuesTmp(
-        filters: GenericFilter = {},
-        column: KupDataColumn
-    ): boolean {
-        return this._hasIntervalTextFieldFilterValues(filters, column, true);
-    }
-
-    private _hasIntervalTextFieldFilterValues(
-        filters: GenericFilter = {},
-        column: KupDataColumn,
-        tmp: boolean
-    ): boolean {
-        if (column == null) {
-            return false;
-        }
-        if (!this.isColumnFiltrableByInterval(column)) {
-            return false;
-        }
-        let intervalFrom = this._getIntervalTextFieldFilterValue(
-            filters,
-            column.name,
-            FilterInterval.FROM,
-            tmp
-        );
-        if (intervalFrom != null && intervalFrom.trim() != '') {
-            return true;
-        }
-        let intervalTo = this._getIntervalTextFieldFilterValue(
-            filters,
-            column.name,
-            FilterInterval.TO,
-            tmp
-        );
-        if (intervalTo != null && intervalTo.trim() != '') {
-            return true;
-        }
-        return false;
-    }
     /**
      * Triggers when a new filter checkbox becomes checked.
      * @param {GenericFilter} filters - Filters of the component.
@@ -261,94 +208,6 @@ export class FiltersColumnMenu extends Filters {
         return this.isObjFiltrableByInterval(column.obj);
     }
 
-    getIntervalTextFieldFilterValues(
-        filters: GenericFilter = {},
-        column: KupDataColumn
-    ): Array<string> {
-        return this._getIntervalTextFieldFilterValues(filters, column, false);
-    }
-    getIntervalTextFieldFilterValuesTmp(
-        filters: GenericFilter = {},
-        column: KupDataColumn
-    ): Array<string> {
-        return this._getIntervalTextFieldFilterValues(filters, column, true);
-    }
-
-    private _getIntervalTextFieldFilterValues(
-        filters: GenericFilter = {},
-        column: KupDataColumn,
-        tmp: boolean
-    ): Array<string> {
-        if (!this._hasIntervalTextFieldFilterValues(filters, column, tmp)) {
-            return ['', ''];
-        }
-
-        let values = [
-            this._getIntervalTextFieldFilterValue(
-                filters,
-                column.name,
-                FilterInterval.FROM,
-                tmp
-            ),
-            this._getIntervalTextFieldFilterValue(
-                filters,
-                column.name,
-                FilterInterval.TO,
-                tmp
-            ),
-        ];
-        return values;
-    }
-
-    getIntervalTextFieldFilterValue(
-        filters: GenericFilter = {},
-        column: string,
-        index: FilterInterval
-    ): string {
-        return this._getIntervalTextFieldFilterValue(
-            filters,
-            column,
-            index,
-            false
-        );
-    }
-    getIntervalTextFieldFilterValueTmp(
-        filters: GenericFilter = {},
-        column: string,
-        index: FilterInterval
-    ): string {
-        return this._getIntervalTextFieldFilterValue(
-            filters,
-            column,
-            index,
-            true
-        );
-    }
-    private _getIntervalTextFieldFilterValue(
-        filters: GenericFilter = {},
-        column: string,
-        index: FilterInterval,
-        tmp: boolean
-    ): string {
-        let value = '';
-
-        if (filters == null) {
-            return value;
-        }
-        let filter: Filter = filters[column];
-        if (filter == null) {
-            return value;
-        }
-        if (tmp && filter.intervalTmp == null) {
-            return value;
-        }
-        if (!tmp && filter.interval == null) {
-            return value;
-        }
-        value = tmp ? filter.intervalTmp[index] : filter.interval[index];
-        return value;
-    }
-
     setTextFieldFilterValue(
         filters: GenericFilter = {},
         column: string,
@@ -384,59 +243,6 @@ export class FiltersColumnMenu extends Filters {
         }
     }
 
-    setIntervalTextFieldFilterValue(
-        filters: GenericFilter = {},
-        column: string,
-        newFilter: string,
-        index: FilterInterval
-    ) {
-        this._setIntervalTextFieldFilterValue(
-            filters,
-            column,
-            newFilter,
-            index,
-            true
-        );
-    }
-
-    private _setIntervalTextFieldFilterValue(
-        filters: GenericFilter = {},
-        column: string,
-        newFilter: string,
-        index: FilterInterval,
-        tmp: boolean
-    ) {
-        if (filters == null) {
-            return;
-        }
-        let filter: Filter = filters[column];
-        if (filter == null) {
-            filter = {
-                textField: '',
-                textFieldTmp: '',
-                checkBoxes: [],
-                interval: null,
-                intervalTmp: null,
-            };
-            filters[column] = filter;
-        }
-        if (filter.interval == null) {
-            filter.interval = [];
-            filter.interval.push('', '');
-        }
-        if (filter.intervalTmp == null) {
-            filter.intervalTmp = [];
-            filter.intervalTmp.push('', '');
-        }
-        if (tmp) {
-            filter.intervalTmp[index] =
-                newFilter != null ? newFilter.trim() : newFilter;
-        } else {
-            filter.interval[index] =
-                newFilter != null ? newFilter.trim() : newFilter;
-        }
-    }
-
     saveTextualFilters(filters: GenericFilter = {}, column: string) {
         this._setTextFieldFilterValue(
             filters,
@@ -460,7 +266,6 @@ export class FiltersColumnMenu extends Filters {
         column: KupDataColumn
     ): string {
         let txtFilter = this.getTextFilterValue(filters, column.name);
-        let interval = this.getIntervalTextFieldFilterValues(filters, column);
         let chkFilters = this.getCheckBoxFilterValues(filters, column.name);
 
         let separator = '';
@@ -471,30 +276,6 @@ export class FiltersColumnMenu extends Filters {
             column.decimals
         );
         if (txtFilter != '') {
-            separator = ' AND ';
-        }
-        if (interval[FilterInterval.FROM] != '') {
-            txtFiterRis +=
-                separator +
-                '(>= ' +
-                getValueForDisplay(
-                    interval[FilterInterval.FROM],
-                    column.obj,
-                    column.decimals
-                ) +
-                ')';
-            separator = ' AND ';
-        }
-        if (interval[FilterInterval.TO] != '') {
-            txtFiterRis +=
-                separator +
-                '(<= ' +
-                getValueForDisplay(
-                    interval[FilterInterval.TO],
-                    column.obj,
-                    column.decimals
-                ) +
-                ')';
             separator = ' AND ';
         }
 

--- a/packages/ketchup/src/utils/filters/filters-declarations.ts
+++ b/packages/ketchup/src/utils/filters/filters-declarations.ts
@@ -28,17 +28,16 @@ export interface Filter {
 }
 
 /**
- * This regular expressions returns a match like this one:
- * if the string does not match is null, otherwise the indexes are equal to the object below:
+ * This regular expression returns a match with the following groups:
+ * if the string does not match, it returns null; otherwise, the indexes correspond to:
  *
- * @property {string} 0 - The entire match of the regexp; is equal to the cellValue.
- * @property {string} 1 - Either !' or ' it's the start of the regexp.
- * @property {string} 2 - Either % or null: means the string must start with the given string.
+ * @property {string} 0 - The entire match of the regexp; equal to the cellValue.
+ * @property {string} 1 - Operator: '!', '>', '>=', '<', or '<=' at the start of the regexp.
+ * @property {string} 2 - Either % or null: indicates the string must start with the given string.
  * @property {string} 3 - Either "" or a string with a length.
- * @property {string} 4 - Either % or null: means the string must finish with the given string.
- * @property {string} 5 - Always equal to ': it's the end of the filter.
+ * @property {string} 4 - Either % or null: indicates the string must finish with the given string.
  */
-export const FILTER_ANALIZER = /^('|!')(%){0,1}(.*?)(%){0,1}(')$/;
+export const FILTER_ANALIZER = /^(!|>|>=|<|<=){0,1}'(%){0,1}(.*?)(%){0,1}'$/;
 
 export enum KupGlobalFilterMode {
     SIMPLE = 'simple',

--- a/packages/ketchup/src/utils/filters/filters-declarations.ts
+++ b/packages/ketchup/src/utils/filters/filters-declarations.ts
@@ -1,13 +1,5 @@
 import { KupListNode } from '../../components/kup-list/kup-list-declarations';
 
-/**
- * Interface for ranged filters.
- */
-export enum FilterInterval {
-    FROM = 0,
-    TO = 1,
-}
-
 export interface GenericFilter {
     [index: string]: Filter;
 }

--- a/packages/ketchup/src/utils/filters/filters-declarations.ts
+++ b/packages/ketchup/src/utils/filters/filters-declarations.ts
@@ -23,7 +23,7 @@ export interface Filter {
     textField: string;
     textFieldTmp?: string;
     checkBoxes: ValueDisplayedValue[];
-    interval: string[];
+    interval?: string[];
     intervalTmp?: string[];
 }
 

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -34,11 +34,7 @@ const kupData: KupData = dom.ketchup ? dom.ketchup.data : new KupData();
  * @todo Should contain EVERY row-specific filtering method.
  */
 export class FiltersRows extends Filters {
-    isFilterCompliantForCell(
-        cellValue: KupDataCell,
-        filterValue: string,
-        interval: string[]
-    ) {
+    isFilterCompliantForCell(cellValue: KupDataCell, filterValue: string) {
         if (!cellValue) {
             return false;
         }
@@ -46,16 +42,11 @@ export class FiltersRows extends Filters {
         return this.isFilterCompliantForSimpleValue(
             cellValue.value,
             cellValue.obj,
-            filterValue,
-            interval
+            filterValue
         );
     }
 
-    isFilterCompliantForCellObj(
-        cellValue: KupDataCell,
-        filterValue: string,
-        interval: string[]
-    ) {
+    isFilterCompliantForCellObj(cellValue: KupDataCell, filterValue: string) {
         if (!cellValue) {
             return false;
         }
@@ -65,8 +56,7 @@ export class FiltersRows extends Filters {
         return this.isFilterCompliantForSimpleValue(
             cellValue.obj.k,
             cellValue.obj,
-            filterValue,
-            interval
+            filterValue
         );
     }
 
@@ -167,7 +157,7 @@ export class FiltersRows extends Filters {
 
             const _filterIsNegative: boolean =
                 this.filterIsNegative(filterValue);
-            let b1 = this.isFilterCompliantForCell(cell, filterValue, interval);
+            let b1 = this.isFilterCompliantForCell(cell, filterValue);
             let b2 = _filterIsNegative;
             if (
                 !kupObjects.isNumber(cell.obj) &&
@@ -175,11 +165,7 @@ export class FiltersRows extends Filters {
                 !kupObjects.isTime(cell.obj) &&
                 !kupObjects.isTimestamp(cell.obj)
             ) {
-                b2 = this.isFilterCompliantForCellObj(
-                    cell,
-                    filterValue,
-                    interval
-                );
+                b2 = this.isFilterCompliantForCellObj(cell, filterValue);
             }
 
             if (_filterIsNegative) {
@@ -351,8 +337,7 @@ export class FiltersRows extends Filters {
                     columnFilters.isFilterCompliantForSimpleValue(
                         v,
                         column.obj,
-                        value,
-                        interval
+                        value
                     )
                 ) {
                     values.push({

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -150,10 +150,6 @@ export class FiltersRows extends Filters {
             }
 
             let filterValue = columnFilters.getTextFilterValue(filters, key);
-            let interval = columnFilters.getIntervalTextFieldFilterValues(
-                filters,
-                getColumnByName(columns, key)
-            );
 
             const _filterIsNegative: boolean =
                 this.filterIsNegative(filterValue);
@@ -316,10 +312,6 @@ export class FiltersRows extends Filters {
             comp.filters,
             column.name
         );
-        let interval = columnFilters.getIntervalTextFieldFilterValuesTmp(
-            comp.filters,
-            column
-        );
         let checkboxes = columnFilters.getCheckBoxFilterValues(
             comp.filters,
             column.name
@@ -361,8 +353,8 @@ export class FiltersRows extends Filters {
             textField: value,
             textFieldTmp: value,
             checkBoxes: [],
-            interval: interval,
-            intervalTmp: interval,
+            interval: [],
+            intervalTmp: [],
         };
 
         let tmpRows = this.filterRows(

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -3,11 +3,7 @@ import { KupDataTable } from '../../components/kup-data-table/kup-data-table';
 import { KupTree } from '../../components/kup-tree/kup-tree';
 import { KupDatesFormats } from '../../managers/kup-dates/kup-dates-declarations';
 import { KupDom } from '../../managers/kup-manager/kup-manager-declarations';
-import {
-    FilterInterval,
-    FILTER_ANALIZER,
-    ValueDisplayedValue,
-} from './filters-declarations';
+import { FILTER_ANALIZER, ValueDisplayedValue } from './filters-declarations';
 
 const dom: KupDom = document.documentElement as KupDom;
 

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -191,13 +191,22 @@ export class Filters {
             result = operator === '!' ? value.trim() !== '' : !value.trim();
         } else if (hasStartWildcard && hasEndWildcard) {
             // Contains wildcard
-            result = value.indexOf(filterText) >= 0;
+            result =
+                operator === '!'
+                    ? !(value.indexOf(filterText) >= 0)
+                    : value.indexOf(filterText) >= 0;
         } else if (hasStartWildcard && !hasEndWildcard) {
             // Ends with wildcard
-            result = value.endsWith(filterText);
+            result =
+                operator === '!'
+                    ? !value.endsWith(filterText)
+                    : value.endsWith(filterText);
         } else if (!hasStartWildcard && hasEndWildcard) {
             // Starts with wildcard
-            result = value.startsWith(filterText);
+            result =
+                operator === '!'
+                    ? !value.startsWith(filterText)
+                    : value.startsWith(filterText);
         } else if (!hasStartWildcard && !hasEndWildcard) {
             // Operator match
             switch (operator) {

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -40,7 +40,6 @@ import { Filters } from '../filters/filters';
 import { FiltersColumnMenu } from '../filters/filters-column-menu';
 import {
     FILTER_ANALIZER,
-    FilterInterval,
     GenericFilter,
     ValueDisplayedValue,
 } from '../filters/filters-declarations';

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -39,6 +39,7 @@ import { getValueForDisplay, getValueForDisplay2 } from '../cell-utils';
 import { Filters } from '../filters/filters';
 import { FiltersColumnMenu } from '../filters/filters-column-menu';
 import {
+    FILTER_ANALIZER,
     FilterInterval,
     GenericFilter,
     ValueDisplayedValue,
@@ -519,42 +520,23 @@ export class KupColumnMenu {
             return props;
         }
 
-        let interval =
-            this.filtersColumnMenuInstance.getIntervalTextFieldFilterValues(
+        let filterInitialValue =
+            this.filtersColumnMenuInstance.getTextFilterValue(
                 comp.filters,
-                column
+                column.name
             );
-        let initialValueFrom = interval[FilterInterval.FROM];
-        let initialValueTo = interval[FilterInterval.TO];
 
         props.push({
             'data-storage': {
                 column: column,
-                intervalIndex: FilterInterval.FROM,
-                isInterval: true,
             },
             fullWidth: true,
             helperWhenFocused: true,
-            id: KupColumnMenuIds.TEXTFIELD_FROM,
-            key: KupColumnMenuIds.TEXTFIELD_FROM + column.name,
-            initialValue: initialValueFrom,
+            id: KupColumnMenuIds.TEXTFIELD_FILTER,
+            key: KupColumnMenuIds.TEXTFIELD_FILTER + column.name,
+            initialValue: filterInitialValue,
             isClearable: true,
-            label: dom.ketchup.language.translate(KupLanguageSearch.FROM),
-            trailingIcon: true,
-        });
-        props.push({
-            'data-storage': {
-                column: column,
-                intervalIndex: FilterInterval.TO,
-                isInterval: true,
-            },
-            fullWidth: true,
-            helperWhenFocused: true,
-            id: KupColumnMenuIds.TEXTFIELD_TO,
-            key: KupColumnMenuIds.TEXTFIELD_TO + column.name,
-            initialValue: initialValueTo,
-            isClearable: true,
-            label: dom.ketchup.language.translate(KupLanguageSearch.TO),
+            label: dom.ketchup.language.translate(KupLanguageSearch.SEARCH),
             trailingIcon: true,
         });
 
@@ -578,52 +560,31 @@ export class KupColumnMenu {
             return props;
         }
 
-        let interval =
-            this.filtersColumnMenuInstance.getIntervalTextFieldFilterValues(
+        let filterInitialValue =
+            this.filtersColumnMenuInstance.getTextFilterValue(
                 comp.filters,
-                column
+                column.name
             );
-        let initialValueFrom = interval[FilterInterval.FROM];
-        let initialValueTo = interval[FilterInterval.TO];
 
         props.push({
             'data-storage': {
                 column: column,
-                intervalIndex: FilterInterval.FROM,
-                isInterval: true,
             },
             data: {
                 'kup-text-field': {
                     fullWidth: true,
                     helperWhenFocused: true,
                     isClearable: true,
+                    size: 30,
+                    maxLength: 30,
                     label: dom.ketchup.language.translate(
-                        KupLanguageSearch.FROM
+                        KupLanguageSearch.SEARCH
                     ),
                 },
             },
-            id: KupColumnMenuIds.TEXTFIELD_FROM,
-            key: KupColumnMenuIds.TEXTFIELD_FROM + column.name,
-            initialValue: initialValueFrom,
-            manageSeconds: dom.ketchup.objects.isTimeWithSeconds(column.obj),
-        });
-        props.push({
-            'data-storage': {
-                column: column,
-                intervalIndex: FilterInterval.TO,
-                isInterval: true,
-            },
-            data: {
-                'kup-text-field': {
-                    fullWidth: true,
-                    helperWhenFocused: true,
-                    isClearable: true,
-                    label: dom.ketchup.language.translate(KupLanguageSearch.TO),
-                },
-            },
-            id: KupColumnMenuIds.TEXTFIELD_TO,
-            key: KupColumnMenuIds.TEXTFIELD_TO + column.name,
-            initialValue: initialValueTo,
+            id: KupColumnMenuIds.TEXTFIELD_FILTER,
+            key: KupColumnMenuIds.TEXTFIELD_FILTER + column.name,
+            initialValue: filterInitialValue,
             manageSeconds: dom.ketchup.objects.isTimeWithSeconds(column.obj),
         });
 
@@ -650,70 +611,31 @@ export class KupColumnMenu {
             return props;
         }
 
-        let interval =
-            this.filtersColumnMenuInstance.getIntervalTextFieldFilterValues(
+        let filterInitialValue =
+            this.filtersColumnMenuInstance.getTextFilterValue(
                 comp.filters,
-                column
+                column.name
             );
-        let initialValueFrom = interval[FilterInterval.FROM];
-        let initialValueTo = interval[FilterInterval.TO];
-
-        let suffixFrom = null;
-        let suffixTo = null;
-        if (dom.ketchup.objects.isTimestamp(column.obj)) {
-            suffixFrom = ' 00:00:00';
-            suffixTo = ' 23:59:59';
-            if (initialValueFrom && initialValueFrom.length >= 10) {
-                initialValueFrom = initialValueFrom.substring(0, 10);
-            } else {
-                initialValueFrom = '';
-            }
-            if (initialValueTo && initialValueTo.length >= 10) {
-                initialValueTo = initialValueTo.substring(0, 10);
-            } else {
-                initialValueTo = '';
-            }
-        }
 
         props.push({
             'data-storage': {
                 column: column,
-                suffix: suffixFrom,
-                intervalIndex: FilterInterval.FROM,
-                isInterval: true,
             },
             data: {
                 'kup-text-field': {
                     fullWidth: true,
                     helperWhenFocused: true,
                     isClearable: true,
+                    size: 30,
+                    maxLength: 30,
                     label: dom.ketchup.language.translate(
-                        KupLanguageSearch.FROM
+                        KupLanguageSearch.SEARCH
                     ),
                 },
             },
-            id: KupColumnMenuIds.TEXTFIELD_FROM,
-            key: KupColumnMenuIds.TEXTFIELD_FROM + column.name,
-            initialValue: initialValueFrom,
-        });
-        props.push({
-            'data-storage': {
-                column: column,
-                suffix: suffixTo,
-                intervalIndex: FilterInterval.TO,
-                isInterval: true,
-            },
-            data: {
-                'kup-text-field': {
-                    fullWidth: true,
-                    helperWhenFocused: true,
-                    isClearable: true,
-                    label: dom.ketchup.language.translate(KupLanguageSearch.TO),
-                },
-            },
-            id: KupColumnMenuIds.TEXTFIELD_TO,
-            key: KupColumnMenuIds.TEXTFIELD_TO + column.name,
-            initialValue: initialValueTo,
+            id: KupColumnMenuIds.TEXTFIELD_FILTER,
+            key: KupColumnMenuIds.TEXTFIELD_FILTER + column.name,
+            initialValue: filterInitialValue,
         });
 
         return props;
@@ -791,15 +713,7 @@ export class KupColumnMenu {
                     case 'kup-textfield-cleariconclick':
                     case 'kup-datepicker-cleariconclick':
                     case 'kup-timepicker-cleariconclick':
-                        if (dataStorage['isInterval'] == true) {
-                            this.intervalChange(
-                                comp,
-                                null,
-                                dataStorage['column'],
-                                dataStorage['intervalIndex'],
-                                false
-                            );
-                        } else {
+                        {
                             this.textfieldChange(
                                 comp,
                                 null,
@@ -815,16 +729,7 @@ export class KupColumnMenu {
                     case 'kup-timepicker-itemclick':
                         window.clearTimeout(comp.columnFilterTimeout);
                         comp.columnFilterTimeout = window.setTimeout(() => {
-                            if (dataStorage['isInterval'] == true) {
-                                this.intervalChange(
-                                    comp,
-                                    compEvent.detail.value,
-                                    dataStorage['column'],
-                                    dataStorage['intervalIndex'],
-                                    !isClickEvent,
-                                    dataStorage['suffix']
-                                );
-                            } else {
+                            {
                                 this.textfieldChange(
                                     comp,
                                     compEvent.detail.value,
@@ -922,51 +827,20 @@ export class KupColumnMenu {
         }
         let newFilter = '';
         if (value) {
-            newFilter = this.filtersColumnMenuInstance.normalizeValue(
-                value.trim(),
-                column.obj
-            );
+            if (!value.match(FILTER_ANALIZER)) {
+                newFilter = this.filtersColumnMenuInstance.normalizeValue(
+                    value.trim(),
+                    column.obj
+                );
+            } else {
+                newFilter = value;
+            }
         }
         const newFilters: GenericFilter = { ...comp.filters };
         this.filtersColumnMenuInstance.setTextFieldFilterValue(
             newFilters,
             column.name,
             newFilter
-        );
-        comp.filters = newFilters;
-    }
-
-    intervalChange(
-        comp: KupDataTable | KupTree,
-        value: string,
-        column: KupDataColumn,
-        index: FilterInterval,
-        needNormalize: boolean,
-        suffix?: string
-    ): void {
-        if (!FiltersColumnMenu.isTree(comp)) {
-            comp.resetCurrentPage();
-        }
-        let newFilter = '';
-        if (value) {
-            newFilter = value.trim();
-            if (needNormalize) {
-                newFilter = this.filtersColumnMenuInstance.normalizeValue(
-                    newFilter,
-                    column.obj
-                );
-            }
-            if (suffix != null && newFilter != '') {
-                newFilter = newFilter + suffix;
-            }
-        }
-
-        const newFilters: GenericFilter = { ...comp.filters };
-        this.filtersColumnMenuInstance.setIntervalTextFieldFilterValue(
-            newFilters,
-            column.name,
-            newFilter,
-            index
         );
         comp.filters = newFilters;
     }

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -570,6 +570,7 @@ export class KupColumnMenu {
             'data-storage': {
                 column: column,
             },
+            appendSelection: true,
             data: {
                 'kup-text-field': {
                     fullWidth: true,
@@ -621,6 +622,7 @@ export class KupColumnMenu {
             'data-storage': {
                 column: column,
             },
+            appendSelection: true,
             data: {
                 'kup-text-field': {
                     fullWidth: true,

--- a/packages/ketchup/tests/unit/components/kup-data-table/kup-data-table-helper-filter.spec.ts
+++ b/packages/ketchup/tests/unit/components/kup-data-table/kup-data-table-helper-filter.spec.ts
@@ -52,7 +52,7 @@ describe('kup datatable filtering rows', () => {
                 FLD1: {
                     textField: 'clearly fake filter',
                     checkBoxes: [],
-                    interval: ['', ''],
+                    interval: [],
                 },
             },
             '',
@@ -67,7 +67,7 @@ describe('kup datatable filtering rows', () => {
         const filtered = filterRows(
             mockedRows.rows,
             {
-                FLD1: { textField: 'fra', checkBoxes: [], interval: ['', ''] },
+                FLD1: { textField: 'fra', checkBoxes: [], interval: [] },
             },
             '',
             displayedColumns
@@ -81,8 +81,8 @@ describe('kup datatable filtering rows', () => {
         const filtered = filterRows(
             mockedRows.rows,
             {
-                FLD1: { textField: 'fra', checkBoxes: [], interval: ['', ''] },
-                FLD2: { textField: '', checkBoxes: [], interval: ['12', '12'] },
+                FLD1: { textField: 'fra', checkBoxes: [], interval: [] },
+                FLD2: { textField: `'12'`, checkBoxes: [], interval: [] },
             },
             '',
             displayedColumns
@@ -119,8 +119,8 @@ describe('kup datatable filtering rows', () => {
         const filtered = filterRows(
             mockedRows.rows,
             {
-                FLD1: { textField: 'cas', checkBoxes: [], interval: ['', ''] },
-                FLD2: { textField: '', checkBoxes: [], interval: ['12', '12'] },
+                FLD1: { textField: 'cas', checkBoxes: [], interval: [] },
+                FLD2: { textField: `'12'`, checkBoxes: [], interval: [] },
             },
             'fra',
             displayedColumns
@@ -141,7 +141,7 @@ describe('kup datatable filtering rows', () => {
                     [columnToFilterOn]: {
                         textField: "''",
                         checkBoxes: [],
-                        interval: ['', ''],
+                        interval: [],
                     },
                 },
                 '',
@@ -224,7 +224,7 @@ describe('kup datatable filtering rows', () => {
                             [columnToFilterOn]: {
                                 textField: completeFilter,
                                 checkBoxes: [],
-                                interval: ['', ''],
+                                interval: [],
                             },
                         },
                         '',


### PR DESCRIPTION
Implements missing operators in DataTable filtering, handling different obj types like string, number, Date, Time.
Allows multiple filters in a single textField, separated by `;`.

Changes include:
- `filters.ts` improves matching functions leveraging RegEx matching and available operators. Considers different obj types.
- `filters-column-menu.ts` now set a single textField for Number/Date/Time columns aswell. This is due to the possibility to write multiple filters in a single row, removing the need of 2 fields to specify an interval.
- Removal of _interval_ related code: the whole concept of interval is not useful anymore.
- `filters-declarations.ts` improves `FILTER_ANALYZER` regex to handle different operators.
- Datepicker:
  - Add a prop 'appendSelection' to append the value from the picker with the existing value in the field. It defaults to false to keep the default behavior.
  - Corrects a problem with `maxLength` prop not being overridden if passed through text field props.
- Adapt tests.

Related to this in WebupJS:
https://github.com/smeup/webup.js/pull/1139

