### PR TITLE
NC : feat : manage img tab-bar icon size

### DIFF
--- a/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx
+++ b/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx
@@ -432,8 +432,6 @@ export class KupTabBar {
                                 color={`var(${KupThemeColorValues.PRIMARY})`}
                                 resource={node.icon}
                                 placeholderResource={node.placeholderIcon}
-                                sizeX="24px"
-                                sizeY="24px"
                                 wrapperClass="tab__icon"
                             />
                         ) : null}


### PR DESCRIPTION
removed forced 24px tab-bar icon size.
Restore to 16px 