### PR TITLE
LS25000175: TextArea sizes in INP & illegal char for string shape

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.e2e.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.e2e.ts
@@ -1984,4 +1984,103 @@ describe('kup-input-panel', () => {
         const buttons = await commands.findAll('kup-dropdown-button');
         expect(buttons.length).toBe(1);
     });
+
+    it('render inputpanel with a textarea with fixed dimensions', async () => {
+        const page = await newE2EPage();
+
+        await page.setContent('<kup-input-panel></kup-input-panel>');
+        const inputPanel = await page.find('kup-input-panel');
+        const data = {
+            columns: [
+                // {
+                //     name: 'NAM',
+                //     title: 'Name',
+                //     visible: true,
+                //     maxLength: 50,
+                // },
+                {
+                    name: 'SUR',
+                    title: 'Surname',
+                    visible: true,
+                    maxLength: 1000,
+                    length: 1000,
+                },
+                {
+                    name: 'NOT',
+                    title: 'Note Evasione',
+                    visible: true,
+                    maxLength: 1000,
+                    length: 1000,
+                },
+            ],
+            rows: [
+                {
+                    cells: {
+                        // NAM: {
+                        //     value: '',
+                        //     editable: true,
+                        //     shape: 'ITX',
+                        // },
+                        SUR: {
+                            value: '',
+                            editable: true,
+                            data: {
+                                size: 1000,
+                                maxLength: 1000,
+                            },
+                            shape: 'ITX',
+                        },
+                        NOT: {
+                            value: '',
+                            editable: true,
+                            data: {
+                                size: 1000,
+                                maxLength: 1000,
+                            },
+
+                            shape: 'ITX',
+                        },
+                    },
+                },
+            ],
+        };
+
+        inputPanel.setProperty('data', data);
+
+        await page.waitForChanges();
+
+        const form = await page.find(
+            'kup-input-panel >>> form.input-panel-form'
+        );
+        expect(form).not.toBeNull();
+
+        const textFields = await form.findAll(
+            '.f-cell.string-cell .f-text-field'
+        );
+        expect(textFields).toHaveLength(data.columns.length);
+
+        for (const [i, textField] of textFields.entries()) {
+            const container = await textField.find(
+                '.mdc-text-field--textarea--small'
+            );
+            expect(container).not.toBeNull;
+            const minHeight = (await container.getComputedStyle()).minHeight;
+
+            const minWidth = (await container.getComputedStyle()).minWidth;
+
+            expect(minHeight).toEqual('200px');
+            expect(minWidth).toEqual('300px');
+
+            const label = await textField.find('label');
+            expect(label).not.toBeNull();
+            expect(label).toHaveClass('mdc-label');
+            expect(label).toEqualText(data.columns[i].title);
+
+            const input = await textField.find('textarea');
+            expect(input).not.toBeNull();
+            const value = await input.getProperty('value');
+            expect(value).toBe('');
+            // expect(input).toHaveClass('mdc-text-field--textarea--small');
+        }
+    });
 });

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -26,6 +26,15 @@
     --kup-input-panel-font-size,
     var(--kup-font-size)
   );
+
+  --kup_textfield_textarea_height_conversion_input_panel: var(
+    --kup-textfield-textarea-small-height-conversion-input_panel,
+    200px
+  );
+  --kup_textfield_textarea_small_width_conversion_input_panel: var(
+    --kup-textfield-textarea-small-width-conversion-input_panel,
+    300px
+  );
   --kup_input_panel_label_alignment: var(--kup-input-panel-label-alignment);
   --kup_input_panel_label_width: var(--kup-input-panel-label-width);
   --kup_input_panel_padding: var(--kup-input-panel-padding, 1em 0);
@@ -80,6 +89,19 @@
       .f-cell__content {
         > * {
           width: 100%;
+        }
+      }
+
+      .f-text-field {
+        .mdc-text-field {
+          &.mdc-text-field--textarea {
+            min-height: var(
+              --kup_textfield_textarea_height_conversion_input_panel
+            ) !important;
+            min-width: var(
+              --kup_textfield_textarea_small_width_conversion_input_panel
+            ) !important;
+          }
         }
       }
     }
@@ -148,10 +170,10 @@
         height: unset !important;
       }
     }
-  }
-  .input-panel-form--inline {
-    display: flex;
-    align-items: end;
-    gap: 1rem;
+    .input-panel-form--inline {
+      display: flex;
+      align-items: end;
+      gap: 1rem;
+    }
   }
 }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -91,17 +91,15 @@
           width: 100%;
         }
       }
+    }
 
-      .f-text-field {
-        .mdc-text-field {
-          &.mdc-text-field--textarea {
-            min-height: var(
-              --kup_textfield_textarea_height_input_panel
-            ) !important;
-            min-width: var(
-              --kup_textfield_textarea_width_input_panel
-            ) !important;
-          }
+    .f-text-field {
+      .mdc-text-field {
+        &.mdc-text-field--textarea {
+          min-height: var(
+            --kup_textfield_textarea_height_input_panel
+          ) !important;
+          min-width: var(--kup_textfield_textarea_width_input_panel) !important;
         }
       }
     }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -27,12 +27,12 @@
     var(--kup-font-size)
   );
 
-  --kup_textfield_textarea_height_conversion_input_panel: var(
-    --kup-textfield-textarea-height-conversion-input_panel,
+  --kup_textfield_textarea_height_input_panel: var(
+    --kup-textfield-textarea-height-input_panel,
     200px
   );
-  --kup_textfield_textarea_width_conversion_input_panel: var(
-    --kup-textfield-textarea-width-conversion-input_panel,
+  --kup_textfield_textarea_width_input_panel: var(
+    --kup-textfield-textarea-width-input_panel,
     300px
   );
   --kup_input_panel_label_alignment: var(--kup-input-panel-label-alignment);
@@ -96,10 +96,10 @@
         .mdc-text-field {
           &.mdc-text-field--textarea {
             min-height: var(
-              --kup_textfield_textarea_height_conversion_input_panel
+              --kup_textfield_textarea_height_input_panel
             ) !important;
             min-width: var(
-              --kup_textfield_textarea_width_conversion_input_panel
+              --kup_textfield_textarea_width_input_panel
             ) !important;
           }
         }
@@ -170,10 +170,10 @@
         height: unset !important;
       }
     }
-    .input-panel-form--inline {
-      display: flex;
-      align-items: end;
-      gap: 1rem;
-    }
+  }
+  .input-panel-form--inline {
+    display: flex;
+    align-items: end;
+    gap: 1rem;
   }
 }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -28,11 +28,11 @@
   );
 
   --kup_textfield_textarea_height_conversion_input_panel: var(
-    --kup-textfield-textarea-small-height-conversion-input_panel,
+    --kup-textfield-textarea-height-conversion-input_panel,
     200px
   );
-  --kup_textfield_textarea_small_width_conversion_input_panel: var(
-    --kup-textfield-textarea-small-width-conversion-input_panel,
+  --kup_textfield_textarea_width_conversion_input_panel: var(
+    --kup-textfield-textarea-width-conversion-input_panel,
     300px
   );
   --kup_input_panel_label_alignment: var(--kup-input-panel-label-alignment);
@@ -99,7 +99,7 @@
               --kup_textfield_textarea_height_conversion_input_panel
             ) !important;
             min-width: var(
-              --kup_textfield_textarea_small_width_conversion_input_panel
+              --kup_textfield_textarea_width_conversion_input_panel
             ) !important;
           }
         }

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -740,11 +740,6 @@ function setEditableCell(
             );
 
         case FCellTypes.EDITOR:
-            try {
-                cell.value = JSON.parse(`"${cell.value}"`);
-            } catch (e) {
-                cell.value = JSON.parse(JSON.stringify(cell.value));
-            }
             return (
                 <FTextField
                     {...cell.data}
@@ -958,12 +953,6 @@ function setEditableCell(
                 const isTextArea =
                     (cell.shape ? cell.shape === FCellShapes.MEMO : false) ||
                     (cellType ? cellType === FCellTypes.MEMO : false);
-
-                try {
-                    cell.value = JSON.parse(`"${cell.value}"`);
-                } catch (e) {
-                    cell.value = JSON.parse(JSON.stringify(cell.value));
-                }
                 return (
                     <FTextField
                         {...cell.data}

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -927,7 +927,7 @@ function setEditableCell(
             };
             const onKeyDown = (e: KeyboardEvent) => {
                 cell.data?.onKeyDown?.(e); // call onKeyDown handler if it is set as prop
-                if (e.key === 'Enter' || /^F[1-9]|F1[0-2]$/.test(e.key)) {
+                if (/^F[1-9]|F1[0-2]$/.test(e.key)) {
                     cellEvent(e, props, cellType, FCellEvents.UPDATE);
                 }
             };

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -946,6 +946,12 @@ function setEditableCell(
                     (cell.shape ? cell.shape === FCellShapes.MEMO : false) ||
                     (cellType ? cellType === FCellTypes.MEMO : false) ||
                     cell.data.maxLength >= 256;
+
+                try {
+                    cell.value = JSON.parse(`"${cell.value}"`);
+                } catch (e) {
+                    cell.value = JSON.parse(JSON.stringify(cell.value));
+                }
                 return (
                     <FTextField
                         textArea={isTextArea}
@@ -1461,6 +1467,7 @@ function cellEvent(
                 }
                 break;
             case FCellTypes.EDITOR:
+            case FCellTypes.STRING:
                 value = JSON.stringify(value).slice(1, -1);
                 break;
         }

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -911,6 +911,7 @@ function setEditableCell(
         case FCellTypes.LINK:
         case FCellTypes.MEMO:
         case FCellTypes.STRING:
+            console.log('is string textfield', cell);
             const onChange = (e: InputEvent) =>
                 cellEvent(e, props, cellType, FCellEvents.UPDATE);
             const onInput = (e: InputEvent) => {
@@ -942,13 +943,17 @@ function setEditableCell(
                     ></input>
                 );
             } else {
+                const isTextArea =
+                    (cell.shape ? cell.shape === FCellShapes.MEMO : false) ||
+                    (cellType ? cellType === FCellTypes.MEMO : false) ||
+                    cell.data.maxLength >= 256;
                 return (
                     <FTextField
-                        textArea={
-                            (cell.shape
-                                ? cell.shape === FCellShapes.MEMO
-                                : false) ||
-                            (cellType ? cellType === FCellTypes.MEMO : false)
+                        textArea={isTextArea}
+                        sizing={
+                            isTextArea
+                                ? KupComponentSizing.EXTRA_LARGE
+                                : KupComponentSizing.SMALL
                         }
                         inputType={type}
                         fullWidth={isFullWidth(props) ? true : false}

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -911,7 +911,6 @@ function setEditableCell(
         case FCellTypes.LINK:
         case FCellTypes.MEMO:
         case FCellTypes.STRING:
-            console.log('is string textfield', cell);
             const onChange = (e: InputEvent) =>
                 cellEvent(e, props, cellType, FCellEvents.UPDATE);
             const onInput = (e: InputEvent) => {

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -944,8 +944,7 @@ function setEditableCell(
             } else {
                 const isTextArea =
                     (cell.shape ? cell.shape === FCellShapes.MEMO : false) ||
-                    (cellType ? cellType === FCellTypes.MEMO : false) ||
-                    cell.data.maxLength >= 256;
+                    (cellType ? cellType === FCellTypes.MEMO : false);
 
                 try {
                     cell.value = JSON.parse(`"${cell.value}"`);

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -954,6 +954,7 @@ function setEditableCell(
                 }
                 return (
                     <FTextField
+                        {...cell.data}
                         textArea={isTextArea}
                         sizing={
                             isTextArea
@@ -962,7 +963,6 @@ function setEditableCell(
                         }
                         inputType={type}
                         fullWidth={isFullWidth(props) ? true : false}
-                        {...cell.data}
                         maxLength={
                             (cellType == FCellTypes.NUMBER &&
                                 ((props.column.decimals &&

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -473,7 +473,7 @@
         }
 
         &.mdc-text-field--textarea--medium {
-          height: var(--kup_textfield_textarea_medium_height);
+          min-height: var(--kup_textfield_textarea_medium_height);
         }
 
         &.mdc-text-field--textarea--large {

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -207,6 +207,14 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
         value = formatValue(value, options, false);
     }
 
+    if (props.textArea) {
+        try {
+            value = JSON.parse(`"${value}"`);
+        } catch (e) {
+            value = JSON.parse(JSON.stringify(value));
+        }
+    }
+
     return (
         <div class={classContainerObj}>
             {!props.fullWidth ? labelEl : undefined}


### PR DESCRIPTION
Fixed textarea sizes in input panel component and resolved error CTRL-CHAR-10 also for STRING shapes in fcell.
It can be tested in ges_de10 with this fun:
F(EXD;*SCO;) 1(AR;;AA101752) 2(MB;SCP_SCH;XBRARTI_01) P(AziExe(02) CloFin(Yes)) SS(CONAP() Context() CGr(WUP) ID({webup}))

