### PR TITLE
LS24005508: minor-fix: ignore spaces in filter string

### DIFF
--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -40,7 +40,7 @@ import {
     KupCardFamily,
 } from '../kup-card/kup-card-declarations';
 import { getProps } from '../../utils/utils';
-import { FILTER_ANALIZER } from '../../utils/filters/filters-declarations';
+import { FILTER_ANALYZER } from '../../utils/filters/filters-declarations';
 
 @Component({
     tag: 'kup-date-picker',
@@ -416,7 +416,7 @@ export class KupDatePicker {
         if (eventDetailValue) {
             const isValidFilter =
                 this.isAlphanumeric(eventDetailValue) ||
-                eventDetailValue.match(FILTER_ANALIZER);
+                eventDetailValue.match(FILTER_ANALYZER);
 
             if (this.kupManager.dates.isIsoDate(eventDetailValue)) {
                 if (!isOnInputEvent) {

--- a/packages/ketchup/src/utils/filters/filters-declarations.ts
+++ b/packages/ketchup/src/utils/filters/filters-declarations.ts
@@ -26,8 +26,9 @@ export interface Filter {
  * @property {string} 2 - Either % or null: indicates the string must start with the given string.
  * @property {string} 3 - Either "" or a string with a length.
  * @property {string} 4 - Either % or null: indicates the string must finish with the given string.
+ * This regex ignores spaces at the beginning, at the end, and between the operator and the quoted value.
  */
-export const FILTER_ANALIZER = /^(!|>|>=|<|<=){0,1}'(%){0,1}(.*?)(%){0,1}'$/;
+export const FILTER_ANALYZER = /^\s*(!|>|>=|<|<=)?\s*'(%)?(.*?)(%)?'\s*$/;
 
 export enum KupGlobalFilterMode {
     SIMPLE = 'simple',

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -3,7 +3,7 @@ import { KupDataTable } from '../../components/kup-data-table/kup-data-table';
 import { KupTree } from '../../components/kup-tree/kup-tree';
 import { KupDatesFormats } from '../../managers/kup-dates/kup-dates-declarations';
 import { KupDom } from '../../managers/kup-manager/kup-manager-declarations';
-import { FILTER_ANALIZER, ValueDisplayedValue } from './filters-declarations';
+import { FILTER_ANALYZER, ValueDisplayedValue } from './filters-declarations';
 import { KupObj } from '../../managers/kup-objects/kup-objects-declarations';
 
 const dom: KupDom = document.documentElement as KupDom;
@@ -100,7 +100,7 @@ export class Filters {
      * @param filterValue the filter value to use for check
      */
     filterIsNegative(filterValue: string) {
-        const analyzedFilter = filterValue.match(FILTER_ANALIZER);
+        const analyzedFilter = filterValue.match(FILTER_ANALYZER);
         const filterIsNegative: boolean = analyzedFilter
             ? analyzedFilter[1]?.indexOf('!') >= 0
             : false;
@@ -140,7 +140,7 @@ export class Filters {
                 value.toLowerCase().includes(filter.toLowerCase()) ||
                 this.matchSpecialFilter(
                     value.toLowerCase(),
-                    filter.toLowerCase().match(FILTER_ANALIZER)
+                    filter.toLowerCase().match(FILTER_ANALYZER)
                 )
         );
     }
@@ -264,7 +264,7 @@ export class Filters {
                 // Parse filter using FILTER_ANALIZER
                 const filterMatch = rawFilter
                     .toLowerCase()
-                    .match(FILTER_ANALIZER);
+                    .match(FILTER_ANALYZER);
 
                 if (filterMatch) {
                     const [
@@ -319,7 +319,7 @@ export class Filters {
                 // Parse filter using FILTER_ANALIZER
                 const filterMatch = rawFilter
                     .toLowerCase()
-                    .match(FILTER_ANALIZER);
+                    .match(FILTER_ANALYZER);
 
                 // Convert the value to check to a Date object
                 const normValue = this.normalizeValue(value, obj);

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -39,7 +39,7 @@ import { getValueForDisplay, getValueForDisplay2 } from '../cell-utils';
 import { Filters } from '../filters/filters';
 import { FiltersColumnMenu } from '../filters/filters-column-menu';
 import {
-    FILTER_ANALIZER,
+    FILTER_ANALYZER,
     GenericFilter,
     ValueDisplayedValue,
 } from '../filters/filters-declarations';
@@ -820,7 +820,7 @@ export class KupColumnMenu {
         }
         let newFilter = '';
         if (value) {
-            if (!value.match(FILTER_ANALIZER)) {
+            if (!value.match(FILTER_ANALYZER)) {
                 newFilter = this.filtersColumnMenuInstance.normalizeValue(
                     value.trim(),
                     column.obj


### PR DESCRIPTION
- The filter regex now ignores spaces at the beginning, at the end, and between the operator and the quoted value.
- Spelling is now correct :)