### PR TITLE
LS25000073: fix label in tbl checkbox - INP layout absolute

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
@@ -106,7 +106,8 @@ export type DataAdapterFn = (
     fieldLabel: string,
     currentValue: string,
     cell?: KupInputPanelCell,
-    id?: string
+    id?: string,
+    layout?: KupInputPanelLayout
 ) => Object;
 
 export type InputPanelCells = {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1267,7 +1267,7 @@ export class KupInputPanel {
         const adapter = dataAdapterMap.get(cellType);
 
         return adapter
-            ? adapter(options, fieldLabel, currentValue, cell, col.name)
+            ? adapter(options, fieldLabel, currentValue, cell, col.name, layout)
             : null;
     }
 
@@ -1518,7 +1518,8 @@ export class KupInputPanel {
         _fieldLabel: string,
         _value: string,
         cell: KupInputPanelCell,
-        id: string
+        id: string,
+        layout: KupInputPanelLayout
     ) {
         try {
             let data = JSON.parse(cell.value);
@@ -1569,7 +1570,8 @@ export class KupInputPanel {
                                     data: {
                                         ...this.#mapData(
                                             row.cells[key],
-                                            column
+                                            column,
+                                            layout
                                         ),
                                         disabled:
                                             row.cells[key].editable === false,


### PR DESCRIPTION
When #mapData was called in DataTableAdapter in order to correctly render cells of TBL, layout was not passed and so the fieldLabel was set to the Col.Title and not null. 

The test case was a tbl with checkboxes because Checkbox is the only graphic form usable in TBL whose adapter accepts label.

By passing the layout via DataTableAdapter the (layout.absolute) condition is now corrrectly checked and so fieldLabel is now passed correctly as null.

All tests on Webup.JS with this change passed

