### PR TITLE
LS25000449: fcell min height for datatable row height regulation

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -533,7 +533,7 @@
   }
 
   &.dense {
-    --kup-textfield-fullwidth-height: 28px;
+    --kup-textfield-fullwidth-height: var(--kup_fcell_dense_min_height);
     --kup-textfield-fullwidth-padding: 0px;
     --kup-checkbox-padding: 0px;
     --kup-chip-margin: 0 4px;
@@ -542,14 +542,14 @@
   }
 
   &.medium {
-    --kup-textfield-fullwidth-height: 36px;
+    --kup-textfield-fullwidth-height: var(--kup_fcell_medium_min_height);
     --kup-textfield-fullwidth-padding: 0px;
     min-height: var(--kup_fcell_medium_min_height);
     padding: var(--kup_fcell_padding_medium);
   }
 
   &.wide {
-    --kup-textfield-fullwidth-height: 50px;
+    --kup-textfield-fullwidth-height: var(--kup_fcell_wide_min_height);
     --kup-textfield-fullwidth-padding: 0px;
     min-height: var(--kup_fcell_wide_min_height);
     padding: var(--kup_fcell_padding_wide);

--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -20,6 +20,9 @@
     --kup-fcell-padding-wide,
     var(--kup-space-04) var(--kup-space-03)
   );
+  --kup_fcell_dense_min_height: var(--kup-fcell-medium-min-height, 28px);
+  --kup_fcell_medium_min_height: var(--kup-fcell-medium-min-height, 36px);
+  --kup_fcell_wide_min_height: var(--kup-fcell-wide-min-height, 50px);
 
   background: var(--kup_cell_background);
   box-sizing: border-box;
@@ -534,18 +537,21 @@
     --kup-textfield-fullwidth-padding: 0px;
     --kup-checkbox-padding: 0px;
     --kup-chip-margin: 0 4px;
+    min-height: var(--kup_fcell_dense_min_height);
     padding: var(--kup_fcell_padding_dense);
   }
 
   &.medium {
     --kup-textfield-fullwidth-height: 36px;
     --kup-textfield-fullwidth-padding: 0px;
+    min-height: var(--kup_fcell_medium_min_height);
     padding: var(--kup_fcell_padding_medium);
   }
 
   &.wide {
     --kup-textfield-fullwidth-height: 50px;
     --kup-textfield-fullwidth-padding: 0px;
+    min-height: var(--kup_fcell_wide_min_height);
     padding: var(--kup_fcell_padding_wide);
   }
 }


### PR DESCRIPTION
Fix made in order to avoid "collapsed" data table rows