### PR TITLE
LS25000447: fix: acp size and cmb list display

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.e2e.ts
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.e2e.ts
@@ -83,7 +83,7 @@ describe('kup-autocomplete', () => {
         expect(suggestions).not.toBeNull();
 
         suggestions.forEach((el, index) => {
-            const expectedText = data[index].id;
+            const expectedText = `${data[index].id} - ${data[index].value}`;
             const actualText = el.textContent.trim();
             expect(actualText).toBe(expectedText);
         });

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -568,7 +568,7 @@ export class KupAutocomplete {
     #prepList() {
         return (
             <kup-list
-                displayMode={this.displayMode}
+                displayMode={ItemsDisplayMode.CODE_AND_DESC}
                 {...this.data['kup-list']}
                 isMenu={true}
                 onkup-list-click={(e: CustomEvent<KupListEventPayload>) =>
@@ -577,6 +577,26 @@ export class KupAutocomplete {
                 ref={(el) => (this.#listEl = el as any)}
             ></kup-list>
         );
+    }
+
+    #calcSize() {
+        // Explicitly setting size from sub-components props, if present
+        if (this.data['kup-text-field']?.size) {
+            return this.data['kup-text-field']?.size as number;
+        } else {
+            switch (this.displayMode) {
+                case ItemsDisplayMode.CODE:
+                    return 15;
+                case ItemsDisplayMode.DESCRIPTION:
+                    return 35;
+                case ItemsDisplayMode.CODE_AND_DESC:
+                case ItemsDisplayMode.CODE_AND_DESC_ALIAS:
+                case ItemsDisplayMode.DESC_AND_CODE:
+                    return 50;
+                default:
+                    return 35;
+            }
+        }
     }
 
     /*-------------------------------------------------*/
@@ -644,9 +664,7 @@ export class KupAutocomplete {
                 ? true
                 : false,
             showMarker: this.showMarker,
-            ...(this.displayedValue && {
-                size: this.displayedValue.length,
-            }),
+            size: this.#calcSize(),
         };
         const fullHeight =
             this.rootElement.classList.contains('kup-full-height');

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -516,7 +516,7 @@ export class KupCombobox {
         return (
             <kup-list
                 {...this.data['kup-list']}
-                displayMode={this.displayMode}
+                displayMode={ItemsDisplayMode.CODE_AND_DESC}
                 is-menu
                 showFilter={
                     this.data['kup-list']?.data?.length >= 10 ? true : false

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.e2e.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.e2e.ts
@@ -291,7 +291,7 @@ describe('kup-input-panel', () => {
         expect(listOptions).toHaveLength(data.rows[0].cells.NAT.options.length);
 
         const firstOptionValue = await listOptions[0].find('span');
-        expect(firstOptionValue).toEqualText('Italy');
+        expect(firstOptionValue).toEqualText('ITA - Italy');
         await firstOptionValue.click();
 
         const updatedValue = await input.getProperty('value');


### PR DESCRIPTION
- Lists in acp and cmb now always show both Code and Description.
- Size of acp field now depends on DisplayMode, if not set using sub-component props