### PR TITLE
LS25000375: CMB *CHECK on itemclick - kuplist utility features

### DIFF
--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -521,6 +521,7 @@ export class KupCombobox {
                 showFilter={
                     this.data['kup-list']?.data?.length >= 10 ? true : false
                 }
+                filter={''}
                 onkup-list-click={(e: CustomEvent<KupListEventPayload>) =>
                     this.onKupItemClick(e)
                 }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
@@ -1,4 +1,5 @@
 import { GenericObject, KupEventPayload } from '../../components';
+import { FCellShapes } from '../../f-components/f-cell/f-cell-declarations';
 import {
     KupDataCell,
     KupDataCellOptions,
@@ -224,4 +225,22 @@ export const InputPanelKeyCommands: InputPanelCommand = {
     '*ENT': 'Enter',
     '*PDN': 'PageDown',
     '*PUP': 'PageUp',
+};
+
+export enum CheckTriggeringEvents {
+    BLUR = 'blur',
+    ITEMCLICK = 'itemclick',
+}
+
+export const CheckConditionsByEventType = {
+    blur: (value: FCellShapes) => {
+        return (
+            value === FCellShapes.CHECKBOX ||
+            value === FCellShapes.SWITCH ||
+            value === FCellShapes.COMBOBOX
+        );
+    },
+    itemclick: (value: FCellShapes) => {
+        return value !== FCellShapes.COMBOBOX;
+    },
 };

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -60,6 +60,8 @@ import {
 import { getProps, setProps } from '../../utils/utils';
 import { componentWrapperId } from '../../variables/GenericVariables';
 import {
+    CheckConditionsByEventType,
+    CheckTriggeringEvents,
     DataAdapterFn,
     InputPanelButtonClickHandler,
     InputPanelCells,
@@ -1779,15 +1781,15 @@ export class KupInputPanel {
         });
     }
 
-    async #onBlurHandler(e: CustomEvent<FCellEventPayload>) {
+    async #manageInputPanelCheck(
+        e: CustomEvent<FCellEventPayload>,
+        eventType: CheckTriggeringEvents
+    ) {
         const {
             detail: { column, cell },
         } = e;
 
-        if (
-            cell.shape === FCellShapes.CHECKBOX ||
-            cell.shape === FCellShapes.SWITCH
-        ) {
+        if (CheckConditionsByEventType[eventType](cell?.shape)) {
             return;
         }
 
@@ -2151,7 +2153,9 @@ export class KupInputPanel {
 
         return (
             <Host
-                onKup-cell-blur={this.#onBlurHandler.bind(this)}
+                onKup-cell-blur={(e) =>
+                    this.#manageInputPanelCheck(e, CheckTriggeringEvents.BLUR)
+                }
                 onKup-cell-update={this.#onCellUpdate.bind(this)}
                 onKup-tabbar-click={(e: CustomEvent<KupTabBarEventPayload>) => {
                     this.tabSelected = e.detail.node.id;
@@ -2160,6 +2164,12 @@ export class KupInputPanel {
                 onKup-autocomplete-iconclick={this.#getOptionHandler.bind(this)}
                 onKup-combobox-iconclick={(e) =>
                     this.#getOptionHandler(e, true)
+                }
+                onKup-cell-itemclick={(e) =>
+                    this.#manageInputPanelCheck(
+                        e,
+                        CheckTriggeringEvents.ITEMCLICK
+                    )
                 }
                 onKup-objectfield-searchpayload={(
                     e: CustomEvent<FObjectFieldEventPayload>

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -147,12 +147,10 @@ export class KupList {
      * Reference to the input element.
      */
     #inputEl: HTMLInputElement | HTMLTextAreaElement;
-    #globalFilterTimeout: number;
     #radios: KupRadio[] = [];
     #listItems: HTMLElement[] = [];
     #previouslySelectedItemIndex: number;
     #previouslySelectedItemReached: boolean;
-    #filterValue: string = '';
 
     /*-------------------------------------------------*/
     /*                   E v e n t s                   */
@@ -630,7 +628,7 @@ export class KupList {
                         KupLanguageSearch.SEARCH
                     )}
                     icon={KupThemeIconValues.SEARCH}
-                    value={this.#filterValue}
+                    value={this.filter}
                     onInput={(event) => {
                         this.onFilterValueChange(event);
                     }}
@@ -663,8 +661,7 @@ export class KupList {
 
     onFilterValueChange(event) {
         if (event != null && event.target) {
-            this.#filterValue = event.target.value;
-            this.filter = this.#filterValue;
+            this.filter = event?.target?.value ?? '';
         }
     }
 
@@ -711,6 +708,8 @@ export class KupList {
                 this.#inputEl = inputEl;
             }
         }
+        this.#previouslySelectedItemIndex =
+            this.data.findIndex((node) => node.selected === true) ?? 0;
         this.#kupManager.debug.logRender(this, true);
     }
 

--- a/packages/ketchup/src/f-components/f-cell/f-cell-declarations.ts
+++ b/packages/ketchup/src/f-components/f-cell/f-cell-declarations.ts
@@ -53,6 +53,7 @@ export enum FCellEvents {
     CLICK = 'kup-cell-click',
     ICON_CLICK = 'kup-cell-iconclick',
     INPUT = 'kup-cell-input',
+    ITEMCLICK = 'kup-cell-itemclick', // Exclusively used for combobox
     KEYUP = 'kup-cell-keyup',
     SECONDARY_ICON_CLICK = 'kup-cell-secondaryiconclick',
     UPDATE = 'kup-cell-update',

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -715,6 +715,9 @@ function setEditableCell(
                     onKup-combobox-blur={(
                         e: CustomEvent<KupComboboxEventPayload>
                     ) => cellEvent(e, props, cellType, FCellEvents.BLUR)}
+                    onKup-combobox-itemclick={(
+                        e: CustomEvent<KupComboboxEventPayload>
+                    ) => cellEvent(e, props, cellType, FCellEvents.ITEMCLICK)}
                 />
             );
         case FCellTypes.DATE:


### PR DESCRIPTION
*CHECK on blur created problem in CMB because of the iconClick opening the list but at the same time switching the focus from textField to icon (triggering blur, *CHECK and making the list not open correctly)

In order to fix this, a list of changes has been made:
- **Changed onBlurHandler to manageInputPanelCheck**: accepting an event and one string between "blur" and "itemclick" in order to differentiate the checks to make based on the type of event captured.
- **CheckConditionsByEventType const** : The controls used by manageInputPanelCheck are located in this const, declared in kup-input-panel-declarations. By changing the conditions there, the logic also changes in the method.
- **F-Cell changes**: in order to give the correct event payload to the inputPanel f-cell changes has been made to the combo registering a new onKup-combobox-itemclick event listener, generating a cellEvent of ITEMCLICK type.
- **kup-list adjustments**: Added the logic making the cmb selection with keyboard start from the already selected element. Clearing the list filter every time the combo is closed and reopened