### PR TITLE
fix: LS25000413 - change sections columns prop type

### DIFF
--- a/packages/ketchup/src/components/kup-box/kup-box-declarations.ts
+++ b/packages/ketchup/src/components/kup-box/kup-box-declarations.ts
@@ -68,7 +68,7 @@ export interface KupBoxLayout {
 
 export interface KupBoxSection {
     collapsible?: boolean;
-    columns?: number;
+    columns?: string;
     content?: KupBoxObject[];
     dim?: string;
     horizontal?: boolean;


### PR DESCRIPTION
Update type `columns` in `KupBoxSection` interface from `number` to `string`