### PR TITLE
LS25000375: ACP check on itemclick - ACP and CMB list "reset" on check

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -467,6 +467,14 @@ export class KupAutocomplete {
         this.#doConsistencyCheck = true;
         this.#consistencyCheck(value, valueDecode, true);
     }
+    /**
+     * Calls closeList method (acts like a reset).
+     * @param {string} value - Value to be set.
+     */
+    @Method()
+    async reset() {
+        this.#closeList();
+    }
 
     /*-------------------------------------------------*/
     /*           P r i v a t e   M e t h o d s         */

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -422,6 +422,14 @@ export class KupCombobox {
     async setValue(value: string, valueDecode?: string) {
         this.#consistencyCheck(value, valueDecode, true);
     }
+    /**
+     * Calls closeList method (acts like a reset).
+     * @param {string} value - Value to be set.
+     */
+    @Method()
+    async reset() {
+        this.#closeList();
+    }
 
     /*-------------------------------------------------*/
     /*           P r i v a t e   M e t h o d s         */

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-declarations.ts
@@ -1,4 +1,5 @@
 import { GenericObject, KupEventPayload } from '../../components';
+import { FCell } from '../../f-components/f-cell/f-cell';
 import { FCellShapes } from '../../f-components/f-cell/f-cell-declarations';
 import {
     KupDataCell,
@@ -237,10 +238,13 @@ export const CheckConditionsByEventType = {
         return (
             value === FCellShapes.CHECKBOX ||
             value === FCellShapes.SWITCH ||
-            value === FCellShapes.COMBOBOX
+            value === FCellShapes.COMBOBOX ||
+            value === FCellShapes.AUTOCOMPLETE
         );
     },
     itemclick: (value: FCellShapes) => {
-        return value !== FCellShapes.COMBOBOX;
+        return (
+            value !== FCellShapes.COMBOBOX && value !== FCellShapes.AUTOCOMPLETE
+        );
     },
 };

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -272,6 +272,13 @@ export class KupInputPanel {
         [FCellTypes.DATE, 'kup-date-picker'],
         [FCellTypes.TIME, 'kup-time-picker'],
     ]);
+    #cellTypesNeedingReset: Map<FCellTypes, string> = new Map<
+        FCellTypes,
+        string
+    >([
+        [FCellTypes.COMBOBOX, 'kup-combobox'],
+        [FCellTypes.AUTOCOMPLETE, 'kup-autocomplete'],
+    ]);
     #cellCustomRender: Map<
         FCellShapes,
         (
@@ -1113,20 +1120,20 @@ export class KupInputPanel {
                     cell,
                     cell.shape
                 );
-                const componentQuery = this.#cellTypeComponents.get(cellType);
-                if (!componentQuery) {
-                    return;
-                }
+                const queryCompSetValue =
+                    this.#cellTypeComponents.get(cellType);
+                const queryCompNeedsReset =
+                    this.#cellTypesNeedingReset.get(cellType);
 
-                const el: any = this.rootElement.shadowRoot.querySelector(
-                    `${componentQuery}[id='${column.name.replace(
-                        /\//g,
-                        '\\$1'
-                    )}']`
-                );
-                if (cell.value) {
-                    el?.setValue(cell.value);
-                }
+                if (!queryCompSetValue && !queryCompNeedsReset) return;
+
+                const selector =
+                    (queryCompSetValue ?? queryCompNeedsReset) +
+                    `[id='${column.name.replace(/\//g, '\\$1')}']`;
+                const el: any =
+                    this.rootElement.shadowRoot.querySelector(selector);
+
+                queryCompNeedsReset ? el?.reset() : el?.setValue?.(cell.value);
             })
         );
 

--- a/packages/ketchup/src/f-components/f-cell/f-cell-declarations.ts
+++ b/packages/ketchup/src/f-components/f-cell/f-cell-declarations.ts
@@ -53,7 +53,7 @@ export enum FCellEvents {
     CLICK = 'kup-cell-click',
     ICON_CLICK = 'kup-cell-iconclick',
     INPUT = 'kup-cell-input',
-    ITEMCLICK = 'kup-cell-itemclick', // Exclusively used for combobox
+    ITEMCLICK = 'kup-cell-itemclick', // Used for CMB and ACP
     KEYUP = 'kup-cell-keyup',
     SECONDARY_ICON_CLICK = 'kup-cell-secondaryiconclick',
     UPDATE = 'kup-cell-update',

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -622,6 +622,9 @@ function setEditableCell(
                     onKup-autocomplete-blur={(
                         e: CustomEvent<KupAutocompleteEventPayload>
                     ) => cellEvent(e, props, cellType, FCellEvents.BLUR)}
+                    onKup-autocomplete-itemclick={(
+                        e: CustomEvent<KupAutocompleteEventPayload>
+                    ) => cellEvent(e, props, cellType, FCellEvents.ITEMCLICK)}
                 />
             );
         case FCellTypes.CHECKBOX:


### PR DESCRIPTION
Added *CHECK on itemclick for ACP (in the same way it was done for the CMB)

Small optimization for the mapCells method in kup-input-panel and added a new reset() method call.
This call is right now only used for ACP and CMB and its task is to close every list found open to avoid visualisation or "data" errors caused by a simultaneous *CHECK and a list opening FUN