### PR TITLE
LS25000486: campi input panel appiccicati ai bottoni

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -38,7 +38,10 @@
   --kup_input_panel_label_alignment: var(--kup-input-panel-label-alignment);
   --kup_input_panel_label_width: var(--kup-input-panel-label-width);
   --kup_input_panel_padding: var(--kup-input-panel-padding, 1em 0);
-  --kup_input_panel_padding--inline: var(--kup-input-panel-padding--inline, 0);
+  --kup_input_panel_padding--inline: var(
+    --kup-input-panel-padding--inline,
+    1em 0
+  );
   --kup_input_panel_absolute_max_height: var(
     --kup-input-panel-absolute-max-height,
     /* 716px comes from the maximum number of lines (32) multiplied by the default height per line (22px) plus 12px for the possibility that the scrollbar will be rendered */


### PR DESCRIPTION
Fixed behavior in input panel when display is inline-flex and changed padding value.
An example is reachable at F(EXD;*SCO;) 1(CN;CLI;) 2(MB;SCP_SCH;C5D010_OGB) P(FUNZ(MOD) EIM(1)) in ges_de10. 
