### PR TITLE
LS25000485: disalliineamento campo input panel

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.scss
@@ -73,6 +73,7 @@
       white-space: nowrap;
       padding: var(--kup_input_panel_padding--inline);
       display: inline-flex;
+      align-items: flex-end;
     }
 
     &--column {


### PR DESCRIPTION
Fixed wrong behavior of alignment in input panel when using inline-flex display.
The example can be reached at: F(EXD;*SCO;) 1(CN;CLI;) 2(MB;SCP_SCH;C5D010_OGB) P(FUNZ(MOD) EIM(1))