### PR TITLE
LS25000533: fix focus on cmb filter on first open

### DIFF
--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -473,10 +473,7 @@ export class KupCombobox {
             };
         }
         this.#kupManager.addClickCallback(this.#clickCb, true);
-        window.setTimeout(
-            () => document.getElementById('global-filter').focus(),
-            100
-        );
+        window.setTimeout(() => this.#listEl.setFocus(), 300);
     }
 
     #closeList() {
@@ -484,7 +481,7 @@ export class KupCombobox {
         this.#listEl.menuVisible = false;
         this.#kupManager.dynamicPosition.stop(this.#listEl);
         this.#kupManager.removeClickCallback(this.#clickCb);
-        window.setTimeout(() => this.#listEl.setBlur(), 100);
+        window.setTimeout(() => this.#listEl.setBlur(), 300);
     }
 
     #isListOpened(): boolean {

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -473,7 +473,10 @@ export class KupCombobox {
             };
         }
         this.#kupManager.addClickCallback(this.#clickCb, true);
-        window.setTimeout(() => this.#listEl.setFocus(), 100);
+        window.setTimeout(
+            () => document.getElementById('global-filter').focus(),
+            100
+        );
     }
 
     #closeList() {
@@ -529,7 +532,6 @@ export class KupCombobox {
                 showFilter={
                     this.data['kup-list']?.data?.length >= 10 ? true : false
                 }
-                filter={''}
                 onkup-list-click={(e: CustomEvent<KupListEventPayload>) =>
                     this.onKupItemClick(e)
                 }

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -254,6 +254,7 @@ export class KupCombobox {
     onKupIconClick() {
         if (this.#textfieldWrapper.classList.contains('toggled')) {
             this.#closeList();
+            this.#listEl?.setBlur();
         } else {
             this.#openList();
             this.kupIconClick.emit({
@@ -263,6 +264,7 @@ export class KupCombobox {
                 inputValue: this.#textfieldEl.value,
                 open: this.#textfieldWrapper.classList.contains('toggled'),
             });
+            this.#listEl?.setFocus();
         }
     }
 
@@ -473,7 +475,6 @@ export class KupCombobox {
             };
         }
         this.#kupManager.addClickCallback(this.#clickCb, true);
-        window.setTimeout(() => this.#listEl.setFocus(), 300);
     }
 
     #closeList() {
@@ -481,7 +482,6 @@ export class KupCombobox {
         this.#listEl.menuVisible = false;
         this.#kupManager.dynamicPosition.stop(this.#listEl);
         this.#kupManager.removeClickCallback(this.#clickCb);
-        window.setTimeout(() => this.#listEl.setBlur(), 300);
     }
 
     #isListOpened(): boolean {


### PR DESCRIPTION
Fixed a problem where focus was not set on the filter on first combo opening by forcing it every time a list is opened