### PR TITLE
LS25000542: Errata visualizzazione chk in griglialbero

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -281,7 +281,7 @@ const mapData = (cell: KupDataCellOptions, column: KupDataColumn) => {
     if (!cell) {
         return null;
     }
-    const options = cell.options;
+    const options = cell?.options;
     const fieldLabel = column.title;
     const currentValue = cell.value;
     const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
@@ -321,15 +321,16 @@ const MainObjectAdapter = (
     _options: CellOptions[],
     fieldLabel: string,
     currentValue: string,
-    _cell: KupInputPanelCell,
+    cell: KupInputPanelCell,
     _id: string
-) => ({
-    data: {
+) => {
+    const newData = {
         initialValue: currentValue || '',
         label: fieldLabel || '',
         value: currentValue || '',
-    },
-});
+    };
+    cell.data = { ...cell.data, ...newData };
+};
 
 const MainCHKAdapter = (
     _options: CellOptions[],

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -78,9 +78,6 @@ export const FCell: FunctionalComponent<FCellProps> = (
     props: FCellProps,
     children?: VNode[]
 ) => {
-    // if (cellType === FCellTypes.CHECKBOX) {
-    console.log('props in cell', props);
-    // }
     const cell = props.cell;
     const column = props.column;
     const row = props.row;

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -278,7 +278,7 @@ const mapData = (cell: KupDataCellOptions, column: KupDataColumn) => {
     if (!cell) {
         return null;
     }
-    const options = cell?.options;
+    const options = cell.options;
     const fieldLabel = column.title;
     const currentValue = cell.value;
     const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -302,17 +302,15 @@ const MainCHIAdapter = (
     _fieldLabel: string,
     _currentValue: string,
     cell: KupInputPanelCell
-) => {
-    const newData = {
-        data: options?.length
-            ? options?.map((option) => ({
-                  id: option.id,
-                  value: option.id,
-              }))
-            : [],
-    };
-    cell.data = { ...cell.data, ...newData };
-};
+) => ({
+    ...cell.data,
+    data: options?.length
+        ? options?.map((option) => ({
+              id: option.id,
+              value: option.id,
+          }))
+        : [],
+});
 
 const MainObjectAdapter = (
     _options: CellOptions[],
@@ -320,14 +318,12 @@ const MainObjectAdapter = (
     currentValue: string,
     cell: KupInputPanelCell,
     _id: string
-) => {
-    const newData = {
-        initialValue: currentValue || '',
-        label: fieldLabel || '',
-        value: currentValue || '',
-    };
-    cell.data = { ...cell.data, ...newData };
-};
+) => ({
+    ...cell.data,
+    initialValue: currentValue || '',
+    label: fieldLabel || '',
+    value: currentValue || '',
+});
 
 const MainCHKAdapter = (
     _options: CellOptions[],
@@ -372,7 +368,7 @@ const MainRADAdapter = (
     cell?: KupDataCellOptions
 ) => {
     const newData = RADAdapter(currentValue, options);
-    cell.data = { ...cell.data, ...newData };
+    return { ...cell.data, ...newData };
 };
 
 const MainCMBandACPAdapter = (

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -320,9 +320,11 @@ const MainObjectAdapter = (
     _id: string
 ) => ({
     ...cell.data,
-    initialValue: currentValue || '',
-    label: fieldLabel || '',
-    value: currentValue || '',
+    data: {
+        initialValue: currentValue || '',
+        label: fieldLabel || '',
+        value: currentValue || '',
+    },
 });
 
 const MainCHKAdapter = (

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -78,6 +78,9 @@ export const FCell: FunctionalComponent<FCellProps> = (
     props: FCellProps,
     children?: VNode[]
 ) => {
+    // if (cellType === FCellTypes.CHECKBOX) {
+    console.log('props in cell', props);
+    // }
     const cell = props.cell;
     const column = props.column;
     const row = props.row;
@@ -97,9 +100,7 @@ export const FCell: FunctionalComponent<FCellProps> = (
     }
     isEditable = isEditable && props.editable;
 
-    if (cell.options) {
-        cell.data = mapData(cell, column) ?? cell.data;
-    }
+    cell.data = mapData(cell, column) ?? cell.data;
 
     const valueToDisplay = props.previousValue !== cell.value ? cell.value : '';
     const cellType = dom.ketchup.data.cell.getType(cell, shape);


### PR DESCRIPTION
Removed unnecessary check in fcell for mapping data and update object adapter.
Now checkboxes in fun F(EXD;*SCO;) 1(VO;W_LANSILJS;MDI) 2(MB;SCP_SCH;W_LANSILJS) 4(;;MDI_001) in ges_de10 show correctly their value.