### PR TITLE
NC : feat : don't display label input panel abs

### DIFF
--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -71,7 +71,12 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
         props.textArea = true;
     }
 
-    if (props.label && !props.leadingLabel && !props.trailingLabel) {
+    if (
+        props.label &&
+        !props.leadingLabel &&
+        !props.trailingLabel &&
+        !props.legacyLook // do not show label in input panel absolute ( legacy mode )
+    ) {
         labelEl = (
             <div class="mdc-text-field__label-container">
                 <label class="mdc-label" htmlFor="kup-input">


### PR DESCRIPTION
The textfield won't display the label inside the input panel with absolute layout.
The information is passed through the legacyLook prop