### PR TITLE
LS25000564: EXU - Checkbox con label descrizione

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -329,13 +329,12 @@ const MainObjectAdapter = (
 
 const MainCHKAdapter = (
     _options: CellOptions[],
-    fieldLabel: string,
+    _fieldLabel: string,
     currentValue: string,
     cell: KupDataCellOptions
 ) => ({
     ...cell.data,
     checked: currentValue === 'on' || currentValue === '1',
-    label: fieldLabel,
 });
 
 const MainBTNAdapter = (


### PR DESCRIPTION
Removed label field assignment in chk adapter inside fcell.
This has been done because in F(EXD;*SCO;) 1(;;) 2(MB;SCP_SCH;WETEST_EXU) 4(;;CHKCMPINT) checkboxes were showed with the column title next to them.
