### PR TITLE
LS25000589: Unchecked null EXU from spotlight

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3856,8 +3856,8 @@ export class KupDataTable {
     }
 
     #adjustPaginator() {
-        this.computeMaxRowsPerPage()
-        
+        this.computeMaxRowsPerPage();
+
         const numberOfRows = this.#rowsLength;
         // check if current page is valid
         const numberOfPages = Math.ceil(numberOfRows / this.currentRowsPerPage);
@@ -6514,8 +6514,10 @@ export class KupDataTable {
             this.#kupManager.keysBinding.register('enter', () => {
                 const bc = this.rootElement.shadowRoot
                     .activeElement as HTMLInputElement;
-                bc?.blur();
-                this.#handleUpdateClick();
+                if (bc) {
+                    bc?.blur();
+                    this.#handleUpdateClick();
+                }
             });
 
             if (this.hiddenSubmitButton) {


### PR DESCRIPTION
Recalling from spotlight a scheda with an exu inside in ges_de10: 
F(EXD;*SCO;) 1(;;) 2(MB;SCP_SCH;WETEST_EXU) 4(;;CHKCMPINT)
and another one with an exu again: 
F(EXD;*SCO;) 2(MB;SCP_SCH;WETEST_EX4) 4(;;LAY01)
The error "Cannot read properties of null (reading 'getLastFocusedRow')" appeared.
This problem now has been solved checking if the "enter" click event on keyboard rises from spotlight or from datatable.
