### PR TITLE
LS25000589: unchecked null exu from spotlight 

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -6513,7 +6513,10 @@ export class KupDataTable {
                 const bc = this.rootElement.shadowRoot
                     .activeElement as HTMLInputElement;
                 bc?.blur();
-                this.#handleUpdateClick();
+
+                if (bc) {
+                    this.#handleUpdateClick();
+                }
             });
 
             if (this.hiddenSubmitButton) {

--- a/packages/ketchup/src/managers/kup-keys-binding/kup-keys-binding.ts
+++ b/packages/ketchup/src/managers/kup-keys-binding/kup-keys-binding.ts
@@ -13,9 +13,9 @@ export class KupKeysBinding {
         this.#keysEvents = new Map();
         this.#pressedKeys = new Set();
         document.addEventListener('keydown', this.#checkEvent.bind(this));
-        document.addEventListener('keyup', () => {
+        document.addEventListener('keyup', (e: KeyboardEvent) => {
+            this.#clearKey(e);
             this.#pressedKeys.clear();
-            this.#clearKey.bind(this);
         });
         window.addEventListener('blur', () => {
             this.#pressedKeys.clear();


### PR DESCRIPTION
Resolved an error when, clicking on 'enter' on keyboard, event from datatable fires without having a right focused element.