### PR TITLE
LS25000533: Focus on CMB with retry

### DIFF
--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -328,7 +328,22 @@ export class KupList {
 
     @Method()
     async setFocus(): Promise<void> {
-        this.#inputEl?.focus();
+        if (!this.#inputEl) return;
+        let attempts = 0;
+        const maxFocusAttempts = 100;
+        const attemptFocus = () => {
+            if (attempts >= maxFocusAttempts) return;
+            attempts++;
+
+            this.#inputEl.focus();
+            if (
+                document.activeElement !== this.rootElement &&
+                this.#isListOpened()
+            ) {
+                requestAnimationFrame(attemptFocus);
+            }
+        };
+        attemptFocus();
     }
 
     @Method()
@@ -658,6 +673,10 @@ export class KupList {
             }
         }
     };
+
+    #isListOpened(): boolean {
+        return this.menuVisible == true;
+    }
 
     onFilterValueChange(event) {
         if (event != null && event.target) {


### PR DESCRIPTION
With these changes the focus on kup-list global filter for combo has a retry mechanism to temporarely fix the issue of a missing focus on list open.

Note:
_The choice to use this approach has been made after unsuccesfully trying to apply the focus on Promise mechanism used in kup-text-field_