### PR TITLE
LS25000824: errori visualizzazione mobile

### DIFF
--- a/packages/ketchup/src/managers/kup-data/kup-data.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data.ts
@@ -141,10 +141,6 @@ export class KupData {
                 }
             }
 
-            if (cell.data?.maxLength >= 256) {
-                return FCellTypes.MEMO;
-            }
-
             if (dom.ketchup.objects.isBar(obj)) {
                 return FCellTypes.BAR;
             } else if (dom.ketchup.objects.isButton(obj)) {
@@ -179,6 +175,8 @@ export class KupData {
                 return FCellTypes.TIME;
             } else if (dom.ketchup.objects.isVoCodver(obj)) {
                 return FCellTypes.ICON;
+            } else if (cell.data?.maxLength >= 256) {
+                return FCellTypes.MEMO;
             } else {
                 return FCellTypes.STRING;
             }


### PR DESCRIPTION
An object without a shape but with maxLength>=256 caused to render the component automatically as a MEMO type, without checking the obj before.
The condition has been moved as last inside kup-data.