### PR TITLE
LS25000824: errori visualizzazione mobile - fix exb height

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -86,6 +86,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     word-break: normal;
+    min-height: 14px;
   }
 
   &.bar-cell {


### PR DESCRIPTION
Fixed exb height when rows are empty inside a datatable.