### PR TITLE
LS25000834 : Card message box custom label

### DIFF
--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
@@ -10,11 +10,11 @@ const dom: KupDom = document.documentElement as KupDom;
 
 export function prepareMessageBox(component: KupCard): VNode[] {
     const options = component.data.options as KupCardBuiltInMessageBoxOptions;
-    const confirmCancelButtonsExist = !!(options.cancelCb || options.confirmCb);
+    const buttonsExist = !!(options.cancelCb || options.confirmCb);
     return (
         <div class="message-box">
             {options.text ? <div class="text">{options.text}</div> : null}
-            {confirmCancelButtonsExist && (
+            {buttonsExist ? (
                 <div class="button-wrapper">
                     {options.cancelCb ? (
                         <FButton
@@ -44,7 +44,7 @@ export function prepareMessageBox(component: KupCard): VNode[] {
                         ></FButton>
                     ) : null}
                 </div>
-            )}
+            ) : null}
         </div>
     );
 }

--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
@@ -10,18 +10,24 @@ const dom: KupDom = document.documentElement as KupDom;
 
 export function prepareMessageBox(component: KupCard): VNode[] {
     const options = component.data.options as KupCardBuiltInMessageBoxOptions;
-    const buttonsExist = !!(options.cancelCb || options.confirmCb);
+    const confirmCancelButtonsExist = !!(options.cancelCb || options.confirmCb);
+    console.log(component);
+    console.log(component.data.options as KupCardBuiltInMessageBoxOptions);
     return (
         <div class="message-box">
             {options.text ? <div class="text">{options.text}</div> : null}
-            {buttonsExist ? (
+            {confirmCancelButtonsExist && (
                 <div class="button-wrapper">
                     {options.cancelCb ? (
                         <FButton
                             icon="clear"
-                            label={dom.ketchup.language.translate(
-                                KupLanguageGeneric.ABORT
-                            )}
+                            label={
+                                options.cancelLabel
+                                    ? options.cancelLabel
+                                    : dom.ketchup.language.translate(
+                                          KupLanguageGeneric.ABORT
+                                      )
+                            }
                             onClick={options.cancelCb}
                             styling={FButtonStyling.FLAT}
                         ></FButton>
@@ -29,14 +35,18 @@ export function prepareMessageBox(component: KupCard): VNode[] {
                     {options.confirmCb ? (
                         <FButton
                             icon="check"
-                            label={dom.ketchup.language.translate(
-                                KupLanguageGeneric.CONFIRM
-                            )}
+                            label={
+                                options.confirmLabel
+                                    ? options.confirmLabel
+                                    : dom.ketchup.language.translate(
+                                          KupLanguageGeneric.CONFIRM
+                                      )
+                            }
                             onClick={options.confirmCb}
                         ></FButton>
                     ) : null}
                 </div>
-            ) : null}
+            )}
         </div>
     );
 }

--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-message-box.tsx
@@ -11,8 +11,6 @@ const dom: KupDom = document.documentElement as KupDom;
 export function prepareMessageBox(component: KupCard): VNode[] {
     const options = component.data.options as KupCardBuiltInMessageBoxOptions;
     const confirmCancelButtonsExist = !!(options.cancelCb || options.confirmCb);
-    console.log(component);
-    console.log(component.data.options as KupCardBuiltInMessageBoxOptions);
     return (
         <div class="message-box">
             {options.text ? <div class="text">{options.text}</div> : null}

--- a/packages/ketchup/src/components/kup-card/kup-card-declarations.ts
+++ b/packages/ketchup/src/components/kup-card/kup-card-declarations.ts
@@ -69,6 +69,8 @@ export interface KupCardBuiltInMessageBoxOptions {
     cancelCb?: (e: MouseEvent) => unknown;
     confirmCb?: (e: MouseEvent) => unknown;
     text?: string;
+    cancelLabel?: string;
+    confirmLabel?: string;
 }
 /**
  * Options of the built-in Open AI interface.


### PR DESCRIPTION
Added the ( optional ) possibility to add a custom label to both cancel and confirm to the messageBoxOptions by still mantaining the default ABORT and CONFIRM kupLanguage values if the relative prop is not found