### PR TITLE
LS25000900 : fix : TBL scroll to row offset based on col escapes

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -1899,7 +1899,8 @@ export class KupDataTable {
         const id = rowIdentifier;
         const row = this.#getRow(id);
         if (row) {
-            const idx = this.#rows.indexOf(row) - 1;
+            const idx =
+                this.#rows.indexOf(row) - this.calculateScrollToRowOffset();
             if (idx >= 1) {
                 this.#rowsRefs[idx]?.scrollIntoView();
             }
@@ -6619,6 +6620,17 @@ export class KupDataTable {
                 <div class="commands">{commandButtons}</div>
             )
         );
+    }
+
+    calculateScrollToRowOffset(): number {
+        let maxNewlines = 0;
+
+        this.data.columns.forEach((column) => {
+            const newlineCount = (column.title.match(/\n/g) || []).length;
+            maxNewlines = Math.max(maxNewlines, newlineCount);
+        });
+
+        return maxNewlines + 1;
     }
 
     render() {


### PR DESCRIPTION
Calculate a scroll to row offset in order to avoid the scrolled row being hidden under a multi line column title.

This offset is now being calculated by counting the \n occurrences in every column, keeping the higher count and adding one (replacing the - 1 used in scrollToRow method).