### PR TITLE
LS25000949 : fix : InputPanel label rendering with value formatting

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -714,29 +714,24 @@ export class KupInputPanel {
         column: KupDataColumn,
         isAbsoluteLayout?: boolean
     ) {
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const isNumberType = dom.ketchup.objects.isNumber(cell.obj);
+        const isFormattableType =
+            isNumberType ||
+            dom.ketchup.objects.isDate(cell.obj) ||
+            dom.ketchup.objects.isTime(cell.obj) ||
+            dom.ketchup.objects.isTimestamp(cell.obj);
 
-        const baseClass = 'input-panel-label';
-        const additionalClass = isAbsoluteLayout
-            ? ' input-panel-label--legacy-look'
-            : '';
-        const numberClass =
-            cellType === FCellTypes.NUMBER ? ' input-panel-label-number' : '';
+        const classList = ['input-panel-label'];
+        if (isAbsoluteLayout) classList.push('input-panel-label--legacy-look');
+        if (isNumberType) classList.push('input-panel-label-number');
 
-        if (cellType === FCellTypes.NUMBER) {
-            return (
-                <span
-                    class={`${baseClass}${additionalClass}${numberClass}`}
-                    id={column.name}
-                >
-                    {getCellValueForDisplay(column, cell)}
-                </span>
-            );
-        }
+        const value = isFormattableType
+            ? getCellValueForDisplay(column, cell)
+            : cell.value;
 
         return (
-            <span class={`${baseClass}${additionalClass}`} id={column.name}>
-                <FLabel text={cell.value} />
+            <span class={classList.join(' ')} id={column.name}>
+                <FLabel text={value} />
             </span>
         );
     }


### PR DESCRIPTION
Change made for the main objective of reintroducing the number formatting in labels for input legacy.

After these changes the thing that is directly checked is now only the object (removing the shape check in a method entered only when the shape is already a label).
Added the support for formattable types (dates, numbers and times) while always using the newly added FLabel.

The main problem was that getType method checked for both shape and object while giving priority to shape.
The shape, as i said before, is always a label so there will never be a celltype number (now that the CellShape.LABEL has rightfully been added to the getType method check)