### PR TITLE
LS25000895  - bugfix(kup-data-table): right column fixed

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3930,7 +3930,7 @@ export class KupDataTable {
         const validFixedColumnR: boolean =
             this.fixedColumnsR &&
             Number.isInteger(this.fixedColumnsR) &&
-            columnCssIndexR >
+            columnCssIndexR >=
                 this.getVisibleColumns().length - this.fixedColumnsR;
         const validFixedRowIndex =
             Number.isInteger(this.fixedRows) &&
@@ -3955,16 +3955,13 @@ export class KupDataTable {
         }
 
         if (validFixedColumnR) {
-            const prog =
-                columnCssIndexR - (this.getVisibleColumns().length - 1);
-            const progIdx = prog - this.fixedColumnsR;
-            const absIdx = Math.abs(progIdx);
+            const idx = this.getVisibleColumns().length - columnCssIndexR;
             fixedCellClasses[FixedCellsClasses.columnsR] = validFixedColumnR;
             fixedCellClasses['show-column-separator'] =
                 ShowGrid.COMPLETE === this.showGrid ||
                 ShowGrid.COL === this.showGrid;
             fixedCellStyle['right'] =
-                'var(' + (FixedCellsCSSVarsBase.columnsR + absIdx) + ')'; // right value assignment must be reversed
+                'var(' + (FixedCellsCSSVarsBase.columnsR + idx) + ')'; // right value assignment must be reversed
         }
 
         if (validFixedRowIndex) {
@@ -4639,7 +4636,7 @@ export class KupDataTable {
         // For fixed cells styles and classes
         const fixedCellStyle = this.#composeFixedCellStyleAndClass(
             columnIndex + 1 + extraCells,
-            columnIndex + 1,
+            columnIndex,
             0,
             extraCells
         );
@@ -5078,7 +5075,7 @@ export class KupDataTable {
             (column: KupDataColumn, columnIndex) => {
                 const fixedCellStyle = this.#composeFixedCellStyleAndClass(
                     columnIndex + 1 + extraCells,
-                    columnIndex + 1,
+                    columnIndex,
                     0,
                     extraCells
                 );
@@ -5540,6 +5537,7 @@ export class KupDataTable {
                 const selectionStyleAndClass =
                     this.#composeFixedCellStyleAndClass(
                         specialExtraCellsCount,
+                        0,
                         rowCssIndex,
                         specialExtraCellsCount - 1
                     );
@@ -5582,6 +5580,7 @@ export class KupDataTable {
                 const actionsStyleAndClass =
                     this.#composeFixedCellStyleAndClass(
                         specialExtraCellsCount,
+                        0,
                         rowCssIndex,
                         specialExtraCellsCount - 1
                     );
@@ -5749,7 +5748,7 @@ export class KupDataTable {
                 //-- For fixed cells --
                 const fixedStyles = this.#composeFixedCellStyleAndClass(
                     cellIndex + 1 + specialExtraCellsCount,
-                    cellIndex + 1,
+                    cellIndex,
                     rowCssIndex,
                     specialExtraCellsCount
                 );


### PR DESCRIPTION
Handled right column fixed in `kup-data-table` updating index calculation for class names

Reference to Action: LS25000895 - Colonne fisse in matrice 

Tested in webupjs with dev-link. 
I will open a  pull request with test updated as soon as this pr will be closed