### PR TITLE
LS25000922 - fix: unresizabile tooltip

### DIFF
--- a/packages/ketchup/src/components/kup-card/kup-card.tsx
+++ b/packages/ketchup/src/components/kup-card/kup-card.tsx
@@ -373,9 +373,10 @@ export class KupCard {
             const dragHandle: HTMLElement = root.querySelector(
                 '#' + KupCardIds.DRAG_HANDLE
             );
-            const isResizable: boolean = !!!root.querySelector(
-                '.' + KupCardCSSClasses.DIALOG_UNRESIZABLE
+            const isResizable: boolean = !card.classList.contains(
+                KupCardCSSClasses.DIALOG_UNRESIZABLE
             );
+
             if (!this.kupManager.interact.isRegistered(card)) {
                 this.kupManager.interact.dialogify(
                     card,


### PR DESCRIPTION
Fixed `KupCard.dialog()` to check the card's class list for resizability instead of using querySelector, which always returned null.