### PR TITLE
Fix/LS25000922 totals tootlip position

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3642,7 +3642,7 @@ export class KupDataTable {
             }
         } else if (details.area === DataTableAreasEnum.FOOTER) {
             if (details.td && details.column) {
-                this.#totalMenuCoords = { x: e.clientX, y: e.clientY };
+                this.#totalMenuCoords = { x: e.pageX, y: e.pageY };
                 this.#onTotalMenuOpen(details.column);
                 return details;
             }


### PR DESCRIPTION
Fix the tooltip's coordinates to account for the scroll, ensuring it positions correctly relative to its target element even when the page is scrolled.