### PR TITLE
LS25000940 : fix : visible columns in globalfilter row filtering

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
@@ -178,7 +178,8 @@ export function filterRows(
     globalFilter: string = '',
     columns: KupDataColumn[] = [],
     columnFilters?: FiltersColumnMenu,
-    filtersRows?: FiltersRows
+    filtersRows?: FiltersRows,
+    visibleColumns?: string[]
 ): Array<KupDataTableRow> {
     if (filtersRows == null) {
         filtersRows = new FiltersRows();
@@ -189,7 +190,8 @@ export function filterRows(
         filters,
         globalFilter,
         columns,
-        columnFilters
+        columnFilters,
+        visibleColumns
     );
 }
 
@@ -323,7 +325,6 @@ export function groupRows(
     adjustGroupsDistinct(groupRows, totals, distinctObj);
     adjustGroupsAverageOrFormula(groupRows, TotalMode.AVERAGE, totals);
     adjustGroupsAverageOrFormula(groupRows, TotalMode.MATH, totals);
-
     return groupRows;
 }
 

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3777,7 +3777,10 @@ export class KupDataTable {
             this.getRows(),
             this.filters,
             this.globalFilterValue,
-            this.getColumns()
+            this.getColumns(),
+            undefined,
+            undefined,
+            this.visibleColumns
         );
         this.#rowsLength = this.#rowsPointLength();
     }

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -66,7 +66,8 @@ export class FiltersRows extends Filters {
         globalFilter: string = '',
         isUsingGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
-        columnFilters?: FiltersColumnMenu
+        columnFilters?: FiltersColumnMenu,
+        visibleColumns?: string[]
     ): boolean {
         return this.areCellsCompliant(
             r.cells,
@@ -74,7 +75,8 @@ export class FiltersRows extends Filters {
             globalFilter,
             isUsingGlobalFilter,
             columns,
-            columnFilters
+            columnFilters,
+            visibleColumns
         );
     }
 
@@ -84,7 +86,8 @@ export class FiltersRows extends Filters {
         globalFilter: string = '',
         isUsingGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
-        columnFilters?: FiltersColumnMenu
+        columnFilters?: FiltersColumnMenu,
+        visibleColumns?: string[]
     ): boolean {
         if (isUsingGlobalFilter) {
             let retValue = true;
@@ -93,9 +96,11 @@ export class FiltersRows extends Filters {
                 retValue = false;
                 let _filterIsNegative = this.filterIsNegative(globalFilter);
 
-                // Search among all visible columns for the global filter
                 for (let i = 0; i < columns.length; i++) {
-                    if (columns[i].visible == false) {
+                    if (
+                        !columns[i].visible &&
+                        !visibleColumns.includes(columns[i].name)
+                    ) {
                         continue;
                     }
                     const cell = cells[columns[i].name];
@@ -239,7 +244,8 @@ export class FiltersRows extends Filters {
         filters: GenericFilter = {},
         globalFilter: string = '',
         columns: KupDataColumn[] = [],
-        columnFilters?: FiltersColumnMenu
+        columnFilters?: FiltersColumnMenu,
+        visibleColumns?: string[]
     ): Array<KupDataRow> {
         if (!rows || rows == null) {
             return [];
@@ -262,7 +268,8 @@ export class FiltersRows extends Filters {
                         globalFilter,
                         isUsingGlobalFilter,
                         columns,
-                        columnFilters
+                        columnFilters,
+                        visibleColumns
                     )
                 ) {
                     filteredRows[filteredRows.length] = r;


### PR DESCRIPTION
When the data table global filter changed, the only thing checked for column validity for filtering was column.visible. With this pr the added check looks into visible columns too, in order to also add the case of a not visible column forced to visible by the "Columns" setup attribute