### PR TITLE
LS25001055 : fix : differentiated globalfilter and column filter

### DIFF
--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -37,7 +37,7 @@ export class FiltersRows extends Filters {
     isFilterCompliantForCell(
         cellValue: KupDataCell,
         filterValue: string,
-        isTextFilter?: boolean
+        isGlobalFilter?: boolean
     ) {
         if (!cellValue) {
             return false;
@@ -47,14 +47,14 @@ export class FiltersRows extends Filters {
             cellValue.value,
             cellValue.obj,
             filterValue,
-            isTextFilter
+            isGlobalFilter
         );
     }
 
     isFilterCompliantForCellObj(
         cellValue: KupDataCell,
         filterValue: string,
-        isTextFilter?: boolean
+        isGlobalFilter?: boolean
     ) {
         if (!cellValue) {
             return false;
@@ -66,7 +66,7 @@ export class FiltersRows extends Filters {
             cellValue.obj.k,
             cellValue.obj,
             filterValue,
-            isTextFilter
+            isGlobalFilter
         );
     }
 

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -34,7 +34,11 @@ const kupData: KupData = dom.ketchup ? dom.ketchup.data : new KupData();
  * @todo Should contain EVERY row-specific filtering method.
  */
 export class FiltersRows extends Filters {
-    isFilterCompliantForCell(cellValue: KupDataCell, filterValue: string) {
+    isFilterCompliantForCell(
+        cellValue: KupDataCell,
+        filterValue: string,
+        isTextFilter?: boolean
+    ) {
         if (!cellValue) {
             return false;
         }
@@ -42,11 +46,16 @@ export class FiltersRows extends Filters {
         return this.isFilterCompliantForSimpleValue(
             cellValue.value,
             cellValue.obj,
-            filterValue
+            filterValue,
+            isTextFilter
         );
     }
 
-    isFilterCompliantForCellObj(cellValue: KupDataCell, filterValue: string) {
+    isFilterCompliantForCellObj(
+        cellValue: KupDataCell,
+        filterValue: string,
+        isTextFilter?: boolean
+    ) {
         if (!cellValue) {
             return false;
         }
@@ -56,7 +65,8 @@ export class FiltersRows extends Filters {
         return this.isFilterCompliantForSimpleValue(
             cellValue.obj.k,
             cellValue.obj,
-            filterValue
+            filterValue,
+            isTextFilter
         );
     }
 
@@ -123,7 +133,8 @@ export class FiltersRows extends Filters {
                             retValue ||
                             this.isFilterCompliantForValue(
                                 displayedValue,
-                                globalFilter
+                                globalFilter,
+                                isUsingGlobalFilter
                             );
                     }
                     if (retValue == true && !_filterIsNegative) {
@@ -164,7 +175,7 @@ export class FiltersRows extends Filters {
 
             let b1 =
                 (filterValue !== '' &&
-                    this.isFilterCompliantForCell(cell, filterValue)) ||
+                    this.isFilterCompliantForCell(cell, filterValue, true)) ||
                 checkboxValues.some((f) =>
                     this.isFilterCompliantForCell(cell, f.value)
                 ) ||
@@ -183,7 +194,11 @@ export class FiltersRows extends Filters {
             ) {
                 b2 =
                     (filterValue !== '' &&
-                        this.isFilterCompliantForCellObj(cell, filterValue)) ||
+                        this.isFilterCompliantForCellObj(
+                            cell,
+                            filterValue,
+                            true
+                        )) ||
                     checkboxValues.some((f) =>
                         this.isFilterCompliantForCellObj(cell, f.value)
                     ) ||

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -94,12 +94,12 @@ export class FiltersRows extends Filters {
         cells: KupDataRowCells,
         filters: GenericFilter = {},
         globalFilter: string = '',
-        isUsingGlobalFilter: boolean = false,
+        isGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
         columnFilters?: FiltersColumnMenu,
         visibleColumns?: string[]
     ): boolean {
-        if (isUsingGlobalFilter) {
+        if (isGlobalFilter) {
             let retValue = true;
             // There are no columns -> display element
             if (columns && columns != null && columns.length > 0) {
@@ -122,7 +122,7 @@ export class FiltersRows extends Filters {
                     retValue = this.isFilterCompliantForValue(
                         cell.value,
                         globalFilter,
-                        isUsingGlobalFilter
+                        isGlobalFilter
                     );
                     let displayedValue = getCellValueForDisplay(
                         columns[i],
@@ -134,7 +134,7 @@ export class FiltersRows extends Filters {
                             this.isFilterCompliantForValue(
                                 displayedValue,
                                 globalFilter,
-                                isUsingGlobalFilter
+                                isGlobalFilter
                             );
                     }
                     if (retValue == true && !_filterIsNegative) {

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -74,7 +74,7 @@ export class FiltersRows extends Filters {
         r: KupDataRow,
         filters: GenericFilter = {},
         globalFilter: string = '',
-        isUsingGlobalFilter: boolean = false,
+        isGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
         columnFilters?: FiltersColumnMenu,
         visibleColumns?: string[]
@@ -83,7 +83,7 @@ export class FiltersRows extends Filters {
             r.cells,
             filters,
             globalFilter,
-            isUsingGlobalFilter,
+            isGlobalFilter,
             columns,
             columnFilters,
             visibleColumns
@@ -270,11 +270,11 @@ export class FiltersRows extends Filters {
         }
         // There are rows to filter
         let filteredRows: Array<KupDataRow> = [];
-        const isUsingGlobalFilter: boolean = !!(globalFilter && columns);
+        const isGlobalFilter: boolean = !!(globalFilter && columns);
 
         if (
             this.hasFilters(filters, columns, columnFilters) ||
-            isUsingGlobalFilter
+            isGlobalFilter
         ) {
             for (let i = 0; i < rows.length; i++) {
                 let r: KupDataRow = rows[i];
@@ -284,7 +284,7 @@ export class FiltersRows extends Filters {
                         r,
                         filters,
                         globalFilter,
-                        isUsingGlobalFilter,
+                        isGlobalFilter,
                         columns,
                         columnFilters,
                         visibleColumns

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -98,7 +98,7 @@ export class FiltersRows extends Filters {
 
                 for (let i = 0; i < columns.length; i++) {
                     if (
-                        (!columns[i].visible === false && !visibleColumns) ||
+                        (columns[i].visible === false && !visibleColumns) ||
                         (visibleColumns?.length > 0 &&
                             !visibleColumns.includes(columns[i].name))
                     ) {
@@ -111,7 +111,8 @@ export class FiltersRows extends Filters {
                     }
                     retValue = this.isFilterCompliantForValue(
                         cell.value,
-                        globalFilter
+                        globalFilter,
+                        isUsingGlobalFilter
                     );
                     let displayedValue = getCellValueForDisplay(
                         columns[i],
@@ -122,7 +123,8 @@ export class FiltersRows extends Filters {
                             retValue ||
                             this.isFilterCompliantForValue(
                                 displayedValue,
-                                globalFilter
+                                globalFilter,
+                                isUsingGlobalFilter
                             );
                     }
                     if (retValue == true && !_filterIsNegative) {

--- a/packages/ketchup/src/utils/filters/filters-rows.ts
+++ b/packages/ketchup/src/utils/filters/filters-rows.ts
@@ -123,8 +123,7 @@ export class FiltersRows extends Filters {
                             retValue ||
                             this.isFilterCompliantForValue(
                                 displayedValue,
-                                globalFilter,
-                                isUsingGlobalFilter
+                                globalFilter
                             );
                     }
                     if (retValue == true && !_filterIsNegative) {

--- a/packages/ketchup/src/utils/filters/filters-tree-items.ts
+++ b/packages/ketchup/src/utils/filters/filters-tree-items.ts
@@ -32,10 +32,10 @@ export class FiltersTreeItems extends FiltersRows {
             return [];
         }
 
-        const isUsingGlobalFilter: boolean = !!(globalFilter && columns);
+        const isGlobalFilter: boolean = !!(globalFilter && columns);
 
         if (
-            !isUsingGlobalFilter &&
+            !isGlobalFilter &&
             !this.hasFilters(filters, columns, columnFilters)
         ) {
             this.setAllVisible(items);
@@ -47,7 +47,7 @@ export class FiltersTreeItems extends FiltersRows {
                     items[i],
                     filters,
                     globalFilter,
-                    isUsingGlobalFilter,
+                    isGlobalFilter,
                     columns,
                     columnFilters
                 )
@@ -61,7 +61,7 @@ export class FiltersTreeItems extends FiltersRows {
         node: KupTreeNode,
         filters: GenericFilter = {},
         globalFilter: string = '',
-        isUsingGlobalFilter: boolean = false,
+        isGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
         columnFilters?: FiltersColumnMenu
     ): boolean {
@@ -77,17 +77,17 @@ export class FiltersTreeItems extends FiltersRows {
                 cellsHolder,
                 filters,
                 globalFilter,
-                isUsingGlobalFilter,
+                isGlobalFilter,
                 columns,
                 columnFilters
             );
         }
 
-        if (isUsingGlobalFilter == true) {
+        if (isGlobalFilter == true) {
             retValue = this.isFilterCompliantForValue(
                 node.value,
                 globalFilter,
-                isUsingGlobalFilter
+                isGlobalFilter
             );
         }
 
@@ -98,7 +98,7 @@ export class FiltersTreeItems extends FiltersRows {
         node: KupTreeNode,
         filters: GenericFilter = {},
         globalFilter: string,
-        isUsingGlobalFilter: boolean = false,
+        isGlobalFilter: boolean = false,
         columns: KupDataColumn[] = [],
         columnFilters?: FiltersColumnMenu
     ): boolean {
@@ -109,13 +109,13 @@ export class FiltersTreeItems extends FiltersRows {
             node,
             filters,
             globalFilter,
-            isUsingGlobalFilter,
+            isGlobalFilter,
             columns,
             columnFilters
         );
         if (node.disabled != true && node.expandable == true) {
             /** se il ramo è compatibile con il filtro, mostro tutto l'albero sottostante */
-            if (visibility == true && isUsingGlobalFilter) {
+            if (visibility == true && isGlobalFilter) {
                 this.setAllVisible(node.children);
             } else {
                 if (node.children) {
@@ -125,7 +125,7 @@ export class FiltersTreeItems extends FiltersRows {
                                 node.children[i],
                                 filters,
                                 globalFilter,
-                                isUsingGlobalFilter,
+                                isGlobalFilter,
                                 columns,
                                 columnFilters
                             )

--- a/packages/ketchup/src/utils/filters/filters-tree-items.ts
+++ b/packages/ketchup/src/utils/filters/filters-tree-items.ts
@@ -84,7 +84,11 @@ export class FiltersTreeItems extends FiltersRows {
         }
 
         if (isUsingGlobalFilter == true) {
-            retValue = this.isFilterCompliantForValue(node.value, globalFilter);
+            retValue = this.isFilterCompliantForValue(
+                node.value,
+                globalFilter,
+                isUsingGlobalFilter
+            );
         }
 
         return retValue;

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -144,7 +144,7 @@ export class Filters {
             const valueIncludesFilter = isGlobalFilter
                 ? value.toLowerCase().includes(filter.toLowerCase()) &&
                   filter !== ''
-                : value.toLowerCase() === filter.toLowerCase();
+                : value.toLowerCase() == filter.toLowerCase();
             const valueMatchesSpecialFilter = this.matchSpecialFilter(
                 value.toLowerCase(),
                 filter.toLowerCase().match(FILTER_ANALYZER)

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -248,7 +248,7 @@ export class Filters {
         valueToCheck: string,
         obj: any,
         filterValue: string,
-        isTextFilter?: boolean
+        isGlobalFilter?: boolean
     ) {
         if (valueToCheck == null) {
             return false;
@@ -392,7 +392,7 @@ export class Filters {
                 return this.isFilterCompliantForValue(
                     value,
                     normalizedFilter,
-                    isTextFilter
+                    isGlobalFilter
                 );
             }
             return true;

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -135,7 +135,6 @@ export class Filters {
         if (value == null || filterValue == null) {
             return false;
         }
-
         // Split multiple filters and trim each one
         const filters = filterValue.split(';').map((f) => f.trim());
         // All filters must match (AND condition)
@@ -248,7 +247,8 @@ export class Filters {
     isFilterCompliantForSimpleValue(
         valueToCheck: string,
         obj: any,
-        filterValue: string
+        filterValue: string,
+        isTextFilter?: boolean
     ) {
         if (valueToCheck == null) {
             return false;
@@ -262,7 +262,6 @@ export class Filters {
             const rawFilter = filter;
             const normalizedFilter = this.normalizeValue(filter, obj);
             let value = valueToCheck;
-
             let checkByRegularExpression = true;
 
             if (dom.ketchup.objects.isNumber(obj)) {
@@ -390,7 +389,11 @@ export class Filters {
             }
 
             if (checkByRegularExpression) {
-                return this.isFilterCompliantForValue(value, normalizedFilter);
+                return this.isFilterCompliantForValue(
+                    value,
+                    normalizedFilter,
+                    isTextFilter
+                );
             }
             return true;
         });

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -127,7 +127,11 @@ export class Filters {
      * @param filterValue - Filter to apply
      * @returns Whether the value matches the filter
      */
-    isFilterCompliantForValue(value: string, filterValue: string): boolean {
+    isFilterCompliantForValue(
+        value: string,
+        filterValue: string,
+        isGlobalFilter?: boolean
+    ): boolean {
         if (value == null || filterValue == null) {
             return false;
         }
@@ -137,9 +141,10 @@ export class Filters {
         // All filters must match (AND condition)
         return filters.every((filter) => {
             // if filter is '' it should be excluded since it is always included in every possible string and thus always leading to a match!
-            const valueIncludesFilter =
-                value.toLowerCase().includes(filter.toLowerCase()) &&
-                filter !== '';
+            const valueIncludesFilter = isGlobalFilter
+                ? value.toLowerCase().includes(filter.toLowerCase()) &&
+                  filter !== ''
+                : value.toLowerCase() === filter.toLowerCase();
             const valueMatchesSpecialFilter = this.matchSpecialFilter(
                 value.toLowerCase(),
                 filter.toLowerCase().match(FILTER_ANALYZER)


### PR DESCRIPTION
Corrected a typo, ! in the filters-rows if condition.

By now passing a boolean optional value to the isFilterCompliantForValue method now it can differentiate between:
- GlobalFilter: needs an "inclusion" match for the provided string
- ColumnFilter (checkbox with left click on col): needs an exact match