### PR TITLE
LS25001091 - fix: AML focus on first element

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -3203,6 +3203,10 @@ export namespace Components {
         "setBlur": () => Promise<void>;
         "setFocus": () => Promise<void>;
         /**
+          * Focuses the first element of the list.
+         */
+        "setFocusOnFirstEl": () => Promise<void>;
+        /**
           * Sets the props to the component.
           * @param props - Object containing props that will be set to the component.
          */

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -509,6 +509,7 @@ export class KupAutocomplete {
         const topOffset = hasError || hasAlert ? -20 : 0;
         this.#textfieldWrapper.classList.add('toggled');
         this.#listEl.menuVisible = true;
+        this.#listEl.setFocusOnFirstEl();
         const elStyle = this.#listEl.style;
         elStyle.height = 'auto';
         elStyle.minWidth = this.#textfieldWrapper.clientWidth + 'px';

--- a/packages/ketchup/src/components/kup-list/kup-list.tsx
+++ b/packages/ketchup/src/components/kup-list/kup-list.tsx
@@ -203,6 +203,14 @@ export class KupList {
     /*-------------------------------------------------*/
 
     /**
+     * Focuses the first element of the list.
+     */
+    @Method()
+    async setFocusOnFirstEl() {
+        this.focused = 0;
+    }
+
+    /**
      * Focuses the next element of the list.
      */
     @Method()

--- a/packages/ketchup/src/components/kup-list/readme.md
+++ b/packages/ketchup/src/components/kup-list/readme.md
@@ -125,6 +125,16 @@ Type: `Promise<void>`
 
 
 
+### `setFocusOnFirstEl() => Promise<void>`
+
+Focuses the first element of the list.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `setProps(props: GenericObject) => Promise<void>`
 
 Sets the props to the component.


### PR DESCRIPTION
Fix on the AML component regarding the selection of the first element with the `Enter` key, caused by the lack of focus on the first element of the `kup-list`. 
A method has been added that is called upon the creation of the `kup-list`, setting the `focus` state to the first element.

Video:
https://youtu.be/TBTxvRA33mQ