### PR TITLE
LS25001113 : fix : corrected table height calculations

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
@@ -682,6 +682,7 @@ th.obj:hover span:not(.overlay-action) {
   --kup-extradense-legacy-look-padding: var(--kup-space-00) var(--kup-space-03);
   --kup-textfield-extrasmall-padding: var(--kup-extradense-legacy-look-padding);
   --kup-textfield-extrasmall-height: 20px;
+
   th .header-cell__content {
     font-family: var(--kup_datatable_font_family_monospace);
     white-space: pre !important;
@@ -704,5 +705,9 @@ th.obj:hover span:not(.overlay-action) {
     &.wide {
       min-height: var(--kup_fcell_wide_min_height);
     }
+  }
+  table.row-separation > tbody > tr > td {
+    box-shadow: 0px 1px var(--kup-border-subtle);
+    border-bottom: 0px;
   }
 }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -1,7 +1,7 @@
 import { KupInputPanelLayout } from './kup-input-panel-declarations';
 
 export const CHAR_WIDTH = 10;
-export const ROW_HEIGHT = 22;
+export const ROW_HEIGHT = 20;
 
 export const getAbsoluteWidth = (length: number) => {
     if (length == 0) {
@@ -19,7 +19,7 @@ export const getAbsoluteWidth = (length: number) => {
     return length * CHAR_WIDTH;
 };
 
-export const FONT_SIZE = 12;
+export const FONT_SIZE = 14;
 export const FONT_SIZE_TO_WIDTH_RATIO = 1.666666666666667;
 export const SINGLE_CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO;
 
@@ -52,7 +52,7 @@ export const getAbsoluteTop = (row: number) => {
         return null;
     }
 
-    return (row - 1) * ROW_HEIGHT;
+    return (row - 1) * ROW_HEIGHT + row - 1;
 };
 
 export const getAbsoluteLeft = (col: number) => {


### PR DESCRIPTION
Unified rowHeight for absolute layout InputPanel.

Now everything has the same height, even the tables (before this pr there was a difference between normal rows with 22px and table rows with 20,8 px).

Due to the fact that every row is now 20px, if the panel contained many textfields on different rows, they looked attached because their height was also 20px. 
The issue has been solved by separating the rows a little adding the row index to the calculated "top" attribute, creating a small margin between every row.

Changed the border of the table rows with a box shadow, responsible of adding that 0.8 px to the row height (css attrbute effective only in a legacyLook TBL)