### PR TITLE
LS25001308: exu duplicate value in col

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
@@ -10,6 +10,7 @@ import {
     KupDataRow,
     KupDataRowAction,
 } from '../../managers/kup-data/kup-data-declarations';
+import { FCellTypes } from '../../f-components/f-cell/f-cell-declarations';
 
 /**
  * Props of the kup-data-table component.
@@ -356,3 +357,16 @@ export interface KupDatatableCellCheckPayload extends KupEventPayload {
     updatedData: KupDataTableDataset;
     cell?: KupDataCell;
 }
+
+/**
+ * List of types that can duplicate value in all column's cell
+ */
+export const TypesToDuplicate: FCellTypes[] = [
+    FCellTypes.AUTOCOMPLETE,
+    FCellTypes.COMBOBOX,
+    FCellTypes.DATE,
+    FCellTypes.DATETIME,
+    FCellTypes.NUMBER,
+    FCellTypes.STRING,
+    FCellTypes.TIME,
+];

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
@@ -365,7 +365,6 @@ export const TypesToDuplicate: FCellTypes[] = [
     FCellTypes.AUTOCOMPLETE,
     FCellTypes.COMBOBOX,
     FCellTypes.DATE,
-    FCellTypes.DATETIME,
     FCellTypes.NUMBER,
     FCellTypes.STRING,
     FCellTypes.TIME,

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3855,6 +3855,7 @@ export class KupDataTable {
                 currRow.cells[column.name].value = cell.value;
                 currRow.cells[column.name].obj = cell.obj;
                 currRow.cells[column.name].decode = cell.decode;
+                currRow.cells[column.name].data = cell.data;
             }
             return currRow;
         });

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -56,6 +56,7 @@ import {
     KupDatatableUpdatePayload,
     DataTableAreasEnum,
     KupDatatableCellCheckPayload,
+    TypesToDuplicate,
 } from './kup-data-table-declarations';
 import {
     getColumnByName,
@@ -157,7 +158,10 @@ import {
     KupPointerEventTypes,
     KupResizeCallbacks,
 } from '../../managers/kup-interact/kup-interact-declarations';
-import { KupManagerClickCb } from '../../managers/kup-manager/kup-manager-declarations';
+import {
+    KupDom,
+    KupManagerClickCb,
+} from '../../managers/kup-manager/kup-manager-declarations';
 import {
     FCellClasses,
     FCellEventPayload,
@@ -191,6 +195,7 @@ import { KupList } from '../kup-list/kup-list';
 import { KupDropdownButtonEventPayload } from '../kup-dropdown-button/kup-dropdown-button-declarations';
 import { FObjectFieldEventPayload } from '../../f-components/f-object-field/f-object-field-declarations';
 
+const dom: KupDom = document.documentElement as KupDom;
 @Component({
     tag: 'kup-data-table',
     styleUrl: 'kup-data-table.scss',
@@ -1955,13 +1960,10 @@ export class KupDataTable {
             e.key.toLowerCase() === 'd' &&
             e.ctrlKey === true
         ) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            const input = this.rootElement.shadowRoot.activeElement;
+            const input = this.rootElement.shadowRoot
+                .activeElement as HTMLInputElement;
             if (input) {
-                (input as HTMLInputElement).blur();
-                this.#copyCellValueInColumnHandler(input);
+                this.#copyCellValueInColumnHandler(e, input);
             }
         }
     }
@@ -3856,15 +3858,25 @@ export class KupDataTable {
         return this.totals && Object.keys(this.totals).length > 0;
     }
 
-    #copyCellValueInColumnHandler(el: Element) {
+    #copyCellValueInColumnHandler(e: KeyboardEvent, el: HTMLInputElement) {
         const details = this.#getEventDetails(
             this.#kupManager.getEventPath(el, this.rootElement)
         );
 
         const { cell, column, row } = details;
+        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
 
+        if (!TypesToDuplicate.includes(cellType)) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        el.blur();
+
+        const filteredRowIds = this.#rows.map((row) => row.id);
         this.data.rows = this.data.rows.map((currRow) => {
-            if (currRow.id !== row.id) {
+            if (filteredRowIds.includes(currRow.id) && currRow.id !== row.id) {
                 currRow.cells[column.name].value = cell.value;
                 currRow.cells[column.name].obj = cell.obj;
                 currRow.cells[column.name].decode = cell.decode;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -1938,6 +1938,25 @@ export class KupDataTable {
             }
         }
     }
+
+    @Listen('keydown')
+    listenCopyCellValueInColumnListener(e: KeyboardEvent) {
+        if (
+            this.updatableData &&
+            e.key.toLowerCase() === 'd' &&
+            e.ctrlKey === true
+        ) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const input = this.rootElement.shadowRoot.activeElement;
+            if (input) {
+                (input as HTMLInputElement).blur();
+                this.#copyCellValueInColumnHandler(input);
+            }
+        }
+    }
+
     //#endregion
 
     #closeDropCard() {
@@ -3822,6 +3841,24 @@ export class KupDataTable {
 
     #hasTotals() {
         return this.totals && Object.keys(this.totals).length > 0;
+    }
+
+    #copyCellValueInColumnHandler(el: Element) {
+        const details = this.#getEventDetails(
+            this.#kupManager.getEventPath(el, this.rootElement)
+        );
+
+        const { cell, column, row } = details;
+
+        this.data.rows = this.data.rows.map((currRow) => {
+            if (currRow.id !== row.id) {
+                currRow.cells[column.name].value = cell.value;
+                currRow.cells[column.name].obj = cell.obj;
+                currRow.cells[column.name].decode = cell.decode;
+            }
+            return currRow;
+        });
+        this.refresh();
     }
 
     /**

--- a/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
+++ b/packages/ketchup/src/components/kup-date-picker/kup-date-picker.tsx
@@ -352,6 +352,12 @@ export class KupDatePicker {
         }
     }
 
+    @Watch('initialValue')
+    watchInitialValue() {
+        this.setValue(this.initialValue);
+        this.refresh();
+    }
+
     /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
     /*-------------------------------------------------*/

--- a/packages/ketchup/src/components/kup-time-picker/kup-time-picker.tsx
+++ b/packages/ketchup/src/components/kup-time-picker/kup-time-picker.tsx
@@ -353,6 +353,12 @@ export class KupTimePicker {
         }
     }
 
+    @Watch('initialValue')
+    watchInitialValue() {
+        this.setValue(this.initialValue);
+        this.refresh();
+    }
+
     /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
     /*-------------------------------------------------*/

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -1489,12 +1489,14 @@ function cellEvent(
         }
         switch (cellType) {
             case FCellTypes.AUTOCOMPLETE:
+                cell.decode = e.detail?.node?.value;
                 if (cell.data) {
                     cell.data['initialValue'] = value;
                     cell.data['initialValueDecode'] = e.detail?.node?.value;
                 }
                 break;
             case FCellTypes.COMBOBOX:
+                cell.decode = e.detail?.node?.value;
             case FCellTypes.DATE:
             case FCellTypes.TIME:
                 if (cell.data) {


### PR DESCRIPTION
Added shortcut Ctrl+D in exu to duplicate cell value in column, only in filtered rows or all if there are no filters. 

Shortcut available for: AUTOCOMPLETE - COMBOBOX - TEXT - NUMBER - DATE - TIME.