### PR TITLE
LS25001380: kup-data-table: Added limit to rows per page

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -189,6 +189,7 @@ import { KupColumnMenuIds } from '../../utils/kup-column-menu/kup-column-menu-de
 import { KupList } from '../kup-list/kup-list';
 import { KupDropdownButtonEventPayload } from '../kup-dropdown-button/kup-dropdown-button-declarations';
 import { FObjectFieldEventPayload } from '../../f-components/f-object-field/f-object-field-declarations';
+import { KupPerfTuningPriority } from '../../managers/kup-perf-tuning/kup-perf-tuning-declarations';
 
 @Component({
     tag: 'kup-data-table',
@@ -945,17 +946,30 @@ export class KupDataTable {
     computeMaxRowsPerPage() {
         if (this.data?.columns?.length > 0 && this.data?.rows?.length > 0) {
             const columnsNumber = this.data.columns.length;
-            const cellsNumber = this.data.rows.reduce(
-                (acc, r) => acc + Object.keys(r.cells).length,
-                0
-            );
-            const maxCellsNumberPerPage =
-                this.#kupManager.perfTuning.data.maxCellsPerPage;
-            if (cellsNumber > maxCellsNumberPerPage) {
-                // Rounds a number up to the nearest multiple of ten.
-                this.#maxRowsPerPage =
-                    Math.ceil(maxCellsNumberPerPage / columnsNumber / 10) * 10;
+            const perfTuningData = this.#kupManager.perfTuning.data;
+
+            switch (perfTuningData.priority) {
+                case KupPerfTuningPriority.ROWS_PER_PAGE:
+                    this.#maxRowsPerPage = perfTuningData.maxRowsPerPage;
+                    break;
+
+                case KupPerfTuningPriority.CELLS_PER_PAGE:
+                    const cellsNumber = this.data.rows.reduce(
+                        (acc, r) => acc + Object.keys(r.cells).length,
+                        0
+                    );
+                    const maxCellsNumberPerPage =
+                        perfTuningData.maxCellsPerPage;
+                    if (cellsNumber > maxCellsNumberPerPage) {
+                        // Rounds a number up to the nearest multiple of ten.
+                        this.#maxRowsPerPage =
+                            Math.ceil(
+                                maxCellsNumberPerPage / columnsNumber / 10
+                            ) * 10;
+                    }
+                    break;
             }
+
             if (this.rowsPerPage > this.#maxRowsPerPage)
                 this.rowsPerPage = this.#maxRowsPerPage;
         }

--- a/packages/ketchup/src/managers/kup-manager/kup-manager.ts
+++ b/packages/ketchup/src/managers/kup-manager/kup-manager.ts
@@ -39,6 +39,7 @@ import { KupOpenAI } from '../kup-openai/kup-openai';
 import { KupKeysBinding } from '../kup-keys-binding/kup-keys-binding';
 import { KupPerfTuning } from '../kup-perf-tuning/kup-perf-tuning';
 import { KupPerfMonitoring } from '../kup-perf-monitoring/kup-perf-monitoring';
+import { KupPerfTuningPriority } from '../kup-perf-tuning/kup-perf-tuning-declarations';
 
 const dom: KupDom = document.documentElement as KupDom;
 
@@ -207,6 +208,8 @@ export class KupManager {
         );
         this.perfTuning = new KupPerfTuning({
             maxCellsPerPage: Number.MAX_VALUE,
+            maxRowsPerPage: 1000,
+            priority: KupPerfTuningPriority.ROWS_PER_PAGE,
         });
         this.perfMonitoring = new KupPerfMonitoring();
         document.addEventListener('pointerdown', (e) => {

--- a/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning-declarations.ts
+++ b/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning-declarations.ts
@@ -1,3 +1,10 @@
 export interface KupPerfTuningData {
     maxCellsPerPage: number;
+    maxRowsPerPage: number;
+    priority: KupPerfTuningPriority;
+}
+
+export enum KupPerfTuningPriority {
+    CELLS_PER_PAGE = 'cells-per-page',
+    ROWS_PER_PAGE = 'rows-per-page',
 }

--- a/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning.ts
+++ b/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning.ts
@@ -31,26 +31,4 @@ export class KupPerfTuning {
             `perfIndex ${perfIndex}, maxCellsPerPage ${this.data.maxCellsPerPage}`
         );
     }
-
-    mark(checkpoint: string): void {
-        performance.mark(`${checkpoint} - Started`);
-    }
-
-    measure(
-        checkpoint: string,
-        track: string,
-        trackGroup = 'SmeUP Performance Tracking'
-    ): void {
-        performance.measure(`${checkpoint} - Completed`, {
-            start: `${checkpoint} - Started`,
-            detail: {
-                devtools: {
-                    dataType: 'track-entry',
-                    track: `${track} - Tasks`,
-                    trackGroup: trackGroup,
-                    color: 'tertiary-dark',
-                },
-            },
-        });
-    }
 }


### PR DESCRIPTION
It will be possible to set a limit on rows per page or cells per page. With the current settings, the limit is set to 1000 rows per page.

If you need to change the settings, update this code.

```js
this.perfTuning = new KupPerfTuning({
    maxCellsPerPage: Number.MAX_VALUE,
    maxRowsPerPage: 1000,
    priority: KupPerfTuningPriority.ROWS_PER_PAGE,
});
```