### PR TITLE
LS25001463 : feat : CMB and ACP shapes in absolute layout INP - Position and size managment

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete-declarations.ts
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete-declarations.ts
@@ -18,6 +18,7 @@ export enum KupAutocompleteProps {
     serverHandledFilter = 'When true, the items filter is managed server side, otherwise items filter is done client side.',
     showDropDownIcon = 'When true shows the drop-down icon, for open list.',
     showMarker = 'When true shows a small marker on the component',
+    legacyLook = 'When true enables the monospaces look for the ACP component',
 }
 
 export interface KupAutocompleteEventPayload extends KupEventPayload {

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -187,7 +187,7 @@ export class KupAutocomplete {
     @Prop() placeholder: string = 'Type code or description';
     /**
      * Allows legacyLook in ACP
-     * @default "Type code or description"
+     * @default false
      */
     @Prop() legacyLook: boolean = false;
 

--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -185,6 +185,11 @@ export class KupAutocomplete {
      * @default "Type code or description"
      */
     @Prop() placeholder: string = 'Type code or description';
+    /**
+     * Allows legacyLook in ACP
+     * @default "Type code or description"
+     */
+    @Prop() legacyLook: boolean = false;
 
     /*-------------------------------------------------*/
     /*       I n t e r n a l   V a r i a b l e s       */
@@ -686,6 +691,7 @@ export class KupAutocomplete {
                 : false,
             showMarker: this.showMarker,
             size: this.#calcSize(),
+            legacyLook: this.legacyLook,
         };
         const fullHeight =
             this.rootElement.classList.contains('kup-full-height');

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox-declarations.ts
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox-declarations.ts
@@ -19,6 +19,7 @@ export enum KupComboboxProps {
     label = 'When set, its content will be shown as a label.',
     leadingLabel = 'When set to true, the label will be on the left of the component.',
     showMarker = 'When true shows a small marker on the component',
+    legacyLook = 'When true enables the monospaced look for the CMB component',
 }
 
 export interface KupComboboxEventPayload extends KupEventPayload {

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -156,6 +156,11 @@ export class KupCombobox {
      * @default false
      */
     @Prop() showMarker: boolean = false;
+    /**
+     * Allows legacyLook aspect in CMB.
+     * @default false
+     */
+    @Prop() legacyLook: boolean = false;
 
     /**
      * Instance of the KupManager class.
@@ -605,6 +610,7 @@ export class KupCombobox {
                 ? true
                 : false,
             showMarker: this.showMarker,
+            legacyLook: this.legacyLook,
         };
         const fullHeight: boolean =
             this.rootElement.classList.contains('kup-full-height');

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -10,11 +10,11 @@ export const ROW_HEIGHT = 20; // Used for the ACTUAL row height calculations (no
 export const SPACED_ROW_HEIGHT = 22; // Used for the INP total height calculations (accounting for row spacing)
 
 // LABEL SIZES
-export const FONT_SIZE_TO_WIDTH_RATIO = 1.666666666666667; // FontSize to SingleCharWidth ratio
+export const FONT_SIZE_TO_WIDTH_RATIO = 1.764705882352941; // FontSize to SingleCharWidth ratio
 export const SINGLE_CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO; // Single monospace char width
 
 // INP CONSTANTS FOR GRAPHIC FORMs
-export const LEFT_MULTIPLIER = 1.19;
+export const LEFT_MULTIPLIER = 1.15;
 export const GRAPHIC_FORM_WIDTH_MULTIPLIER = 1.35;
 
 export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -1,23 +1,24 @@
+import { FCellShapes } from '../../f-components/f-cell/f-cell-declarations';
 import {
     AbsoluteTblPositioningData,
     KupInputPanelLayout,
 } from './kup-input-panel-declarations';
 
 // General INP constants
-export const FONT_SIZE = 12; // Monospace font size of the INP
-export const CHAR_WIDTH = 10; // Used for field width and left attribute
 export const ROW_HEIGHT = 20; // Used for the ACTUAL row height calculations (no spacing)
 export const SPACED_ROW_HEIGHT = 22; // Used for the INP total height calculations (accounting for row spacing)
+export const LEFT_MULTIPLIER = 1.15; // Multiplier commanding the left attribute "scale"
+export const ADDITIONAL_WIDTH_WITH_ICON = 18; // Additional width added to account for the shape's icon (ACP,CAL,CMB)
 
-// LABEL SIZES
-export const FONT_SIZE_TO_WIDTH_RATIO = 1.764705882352941; // FontSize to SingleCharWidth ratio
-export const SINGLE_CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO; // Single monospace char width
+// Char sizes
+export const FONT_SIZE = 12; // Monospace font size of the INP
+export const FONT_SIZE_TO_WIDTH_RATIO = 1.464705882352941; // FontSize to SingleCharWidth ratio
+export const CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO; // Used for field width and left attribute
 
-// INP CONSTANTS FOR GRAPHIC FORMs
-export const LEFT_MULTIPLIER = 1.15;
-export const GRAPHIC_FORM_WIDTH_MULTIPLIER = 1.35;
-
-export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {
+export const getAbsoluteWidth = (
+    length: number,
+    graphicShapeHasIcon?: boolean
+) => {
     if (length == 0) {
         return CHAR_WIDTH / 2;
     }
@@ -31,15 +32,14 @@ export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {
     }
 
     return (
-        length *
-        CHAR_WIDTH *
-        (isGraphicForm ? GRAPHIC_FORM_WIDTH_MULTIPLIER : 1)
+        length * CHAR_WIDTH +
+        (graphicShapeHasIcon ? ADDITIONAL_WIDTH_WITH_ICON : 0)
     );
 };
 
 export const getLabelAbsoluteWidth = (length: number) => {
     if (length == 0) {
-        return SINGLE_CHAR_WIDTH / 2;
+        return CHAR_WIDTH / 2;
     }
 
     if (!length) {
@@ -47,10 +47,10 @@ export const getLabelAbsoluteWidth = (length: number) => {
     }
 
     if (length === 1) {
-        return 1.5 * SINGLE_CHAR_WIDTH;
+        return 1.5 * CHAR_WIDTH;
     }
 
-    return length * SINGLE_CHAR_WIDTH;
+    return length * CHAR_WIDTH;
 };
 
 export const getAbsoluteHeight = (height: number) => {
@@ -90,7 +90,7 @@ export const getAbsoluteLeft = (col: number) => {
         return null;
     }
 
-    return (col - 1) * CHAR_WIDTH * LEFT_MULTIPLIER;
+    return (col - 1) * 10 * LEFT_MULTIPLIER;
 };
 
 export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
@@ -109,6 +109,10 @@ export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
     return inpRowHeight;
 };
 
-export const isGraphicForm = (shape: string) => {
-    return shape === 'ACP' || shape === 'CMB';
+export const graphicShapeHasIcon = (shape: string) => {
+    return (
+        shape === FCellShapes.AUTOCOMPLETE ||
+        shape === FCellShapes.COMBOBOX ||
+        shape === FCellShapes.DATE
+    );
 };

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -12,7 +12,7 @@ export const ADDITIONAL_WIDTH_WITH_ICON = 18; // Additional width added to accou
 
 // Char sizes
 export const FONT_SIZE = 12; // Monospace font size of the INP
-export const FONT_SIZE_TO_WIDTH_RATIO = 1.464705882352941; // FontSize to SingleCharWidth ratio
+export const FONT_SIZE_TO_WIDTH_RATIO = 1.6; // FontSize to SingleCharWidth ratio
 export const CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO; // Used for field width and left attribute
 
 export const getAbsoluteWidth = (
@@ -33,7 +33,8 @@ export const getAbsoluteWidth = (
 
     return (
         length * CHAR_WIDTH +
-        (graphicShapeHasIcon ? ADDITIONAL_WIDTH_WITH_ICON : 0)
+        (graphicShapeHasIcon ? ADDITIONAL_WIDTH_WITH_ICON : 0) +
+        4 // Additional size to include padding
     );
 };
 

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -6,7 +6,7 @@ import {
 export const CHAR_WIDTH = 10;
 export const ROW_HEIGHT = 20;
 
-export const getAbsoluteWidth = (length: number) => {
+export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {
     if (length == 0) {
         return CHAR_WIDTH / 2;
     }
@@ -19,7 +19,7 @@ export const getAbsoluteWidth = (length: number) => {
         return 1.5 * CHAR_WIDTH;
     }
 
-    return length * CHAR_WIDTH;
+    return length * CHAR_WIDTH * (isGraphicForm ? 1.35 : 1);
 };
 
 export const FONT_SIZE = 12;
@@ -79,7 +79,7 @@ export const getAbsoluteLeft = (col: number) => {
         return null;
     }
 
-    return (col - 1) * CHAR_WIDTH;
+    return (col - 1) * CHAR_WIDTH * 1.19;
 };
 
 export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
@@ -96,4 +96,8 @@ export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
         });
     });
     return inpRowHeight;
+};
+
+export const isGraphicForm = (shape: string) => {
+    return shape === 'ACP' || shape === 'CMB';
 };

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -3,8 +3,19 @@ import {
     KupInputPanelLayout,
 } from './kup-input-panel-declarations';
 
-export const CHAR_WIDTH = 10;
-export const ROW_HEIGHT = 20;
+// General INP constants
+export const FONT_SIZE = 12; // Monospace font size of the INP
+export const CHAR_WIDTH = 10; // Used for field width and left attribute
+export const ROW_HEIGHT = 20; // Used for the ACTUAL row height calculations (no spacing)
+export const SPACED_ROW_HEIGHT = 22; // Used for the INP total height calculations (accounting for row spacing)
+
+// LABEL SIZES
+export const FONT_SIZE_TO_WIDTH_RATIO = 1.666666666666667; // FontSize to SingleCharWidth ratio
+export const SINGLE_CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO; // Single monospace char width
+
+// INP CONSTANTS FOR GRAPHIC FORMs
+export const LEFT_MULTIPLIER = 1.19;
+export const GRAPHIC_FORM_WIDTH_MULTIPLIER = 1.35;
 
 export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {
     if (length == 0) {
@@ -19,12 +30,12 @@ export const getAbsoluteWidth = (length: number, isGraphicForm?: boolean) => {
         return 1.5 * CHAR_WIDTH;
     }
 
-    return length * CHAR_WIDTH * (isGraphicForm ? 1.35 : 1);
+    return (
+        length *
+        CHAR_WIDTH *
+        (isGraphicForm ? GRAPHIC_FORM_WIDTH_MULTIPLIER : 1)
+    );
 };
-
-export const FONT_SIZE = 12;
-export const FONT_SIZE_TO_WIDTH_RATIO = 1.666666666666667;
-export const SINGLE_CHAR_WIDTH = FONT_SIZE / FONT_SIZE_TO_WIDTH_RATIO;
 
 export const getLabelAbsoluteWidth = (length: number) => {
     if (length == 0) {
@@ -79,7 +90,7 @@ export const getAbsoluteLeft = (col: number) => {
         return null;
     }
 
-    return (col - 1) * CHAR_WIDTH * 1.19;
+    return (col - 1) * CHAR_WIDTH * LEFT_MULTIPLIER;
 };
 
 export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -93,7 +93,7 @@ import {
     getAbsoluteWidth,
     getInpComponentAbsoluteHeight,
     getLabelAbsoluteWidth,
-    isGraphicForm,
+    graphicShapeHasIcon,
     SPACED_ROW_HEIGHT,
 } from './kup-input-panel-utils';
 import { FTypography } from '../../f-components/f-typography/f-typography';
@@ -1052,18 +1052,13 @@ export class KupInputPanel {
             field.absoluteHeight = 1;
         }
 
-        if (
-            fieldCell.column.isEditable === false &&
-            isGraphicForm(fieldCell.cell.shape)
-        ) {
-            // Changing cell shape when an ACP or CMB is not editable
-            fieldCell.cell.shape = 'ITX';
-        }
-
         const absoluteWidth =
             fieldCell.cell.shape === FCellShapes.LABEL
                 ? getLabelAbsoluteWidth(length)
-                : getAbsoluteWidth(length, isGraphicForm(fieldCell.cell.shape));
+                : getAbsoluteWidth(
+                      length,
+                      graphicShapeHasIcon(fieldCell.cell.shape)
+                  );
         const absoluteHeight = getAbsoluteHeight(field.absoluteHeight);
         const absoluteTop = getAbsoluteTop(
             field.absoluteRow,

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -94,7 +94,7 @@ import {
     getInpComponentAbsoluteHeight,
     getLabelAbsoluteWidth,
     isGraphicForm,
-    ROW_HEIGHT,
+    SPACED_ROW_HEIGHT,
 } from './kup-input-panel-utils';
 import { FTypography } from '../../f-components/f-typography/f-typography';
 import { KupPointerEventTypes } from '../../managers/kup-interact/kup-interact-declarations';
@@ -492,7 +492,8 @@ export class KupInputPanel {
                 rowContent = this.#renderAbsoluteLayout(inputPanelCell, layout);
                 // 12px is added due to the chance that the horizontal scrollbar will be rendered
                 styleObj.height = `${
-                    getInpComponentAbsoluteHeight(layout) * ROW_HEIGHT + 12
+                    getInpComponentAbsoluteHeight(layout) * SPACED_ROW_HEIGHT +
+                    12
                 }px`;
             } else {
                 if (!layout.sectionsType) {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -93,6 +93,7 @@ import {
     getAbsoluteWidth,
     getInpComponentAbsoluteHeight,
     getLabelAbsoluteWidth,
+    isGraphicForm,
     ROW_HEIGHT,
 } from './kup-input-panel-utils';
 import { FTypography } from '../../f-components/f-typography/f-typography';
@@ -1050,10 +1051,18 @@ export class KupInputPanel {
             field.absoluteHeight = 1;
         }
 
+        if (
+            fieldCell.column.isEditable === false &&
+            isGraphicForm(fieldCell.cell.shape)
+        ) {
+            // Changing cell shape when an ACP or CMB is not editable
+            fieldCell.cell.shape = 'ITX';
+        }
+
         const absoluteWidth =
             fieldCell.cell.shape === FCellShapes.LABEL
                 ? getLabelAbsoluteWidth(length)
-                : getAbsoluteWidth(length);
+                : getAbsoluteWidth(length, isGraphicForm(fieldCell.cell.shape));
         const absoluteHeight = getAbsoluteHeight(field.absoluteHeight);
         const absoluteTop = getAbsoluteTop(
             field.absoluteRow,

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -261,6 +261,10 @@
         }
       }
 
+      &.mdc-text-field--legacy-look {
+        gap: 0px;
+      }
+
       &.mdc-text-field--small {
         height: var(--kup_textfield_small_height) !important;
       }

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.scss
@@ -702,6 +702,7 @@
       }
       .mdc-text-field__input {
         color: var(--kup-text-disabled);
+        cursor: not-allowed;
       }
     }
   }


### PR DESCRIPTION
This PR manages the soon-to-be-added new shapes in absolute layout INP (CMB and ACP)

The changes will enable the legacyLook prop passing from the main components to their respective text-field in order to have a consistent look with the other shapes.

Slightly increased the horizontal space occupied by the INP (adding a left additional multiplier).
This change is made to allow ACP and CMB to correctly display their full content regardless of their icon adding some size to the field.

Added an 18px size to ACP, CMB and DatePicker width to account for their icon size

Unified LAB, ITX, ACP, CMB and DatePicker calculations for their width to avoid confusion.
Lowered the precision of the calculations a bit in order to adapt it to every field

Additional length and shape considerations will also made by the backend