### PR TITLE
Fix/LS25001425 kup data table move column

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -4847,6 +4847,10 @@ export class KupDataTable {
 
             const sortedName = this.visibleColumns.splice(sIdx, 1)[0];
             this.visibleColumns.splice(rIdx, 0, sortedName);
+        } else {
+            this.visibleColumns = this.data.columns
+                .filter((col) => col.visible)
+                .map((col) => col.name);
         }
     }
 

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -1586,6 +1586,10 @@ export class KupDataTable {
             this.visibleColumns = this.visibleColumns.filter(
                 (colName) => colName != column.name
             );
+        } else {
+            this.visibleColumns = this.data.columns
+                .filter((col) => col.name != column.name && col.visible)
+                .map((col) => col.name);
         }
         this.kupColumnRemove.emit({
             comp: this,

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -4848,6 +4848,7 @@ export class KupDataTable {
             const sortedName = this.visibleColumns.splice(sIdx, 1)[0];
             this.visibleColumns.splice(rIdx, 0, sortedName);
         } else {
+            // // Adds the sorted column to visibleColumns to preserve the current column order.
             this.visibleColumns = this.data.columns
                 .filter((col) => col.visible)
                 .map((col) => col.name);


### PR DESCRIPTION
Previously, sorting preserved the column order only in data.columns (which isn’t stored in the state). As a result, when a column was moved and another operation was performed (for example, adding a column), the order state was lost. 

A fix in webub.js and the corresponding e2e test follows.

Add same logic for hide column.