### PR TITLE
LS25001568 : minor-fix : allowing inconsistent values in ACP

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -75,7 +75,7 @@ export class KupAutocomplete {
      * When true, the autocomplete fires the change event even when the value typed isn't included in the autocomplete list.
      * @default false
      */
-    @Prop() allowInconsistentValues: boolean = false;
+    @Prop() allowInconsistentValues: boolean = true;
     /**
      * Custom style of the component.
      * @default ""

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1098,6 +1098,9 @@ export class KupInputPanel {
                 showFooter: false,
                 tableHeight: `${absoluteHeight}px`,
             }),
+            ...(fieldCell.cell.shape === FCellShapes.AUTOCOMPLETE && {
+                allowInconsistentValues: true,
+            }),
         };
 
         return (

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1098,9 +1098,6 @@ export class KupInputPanel {
                 showFooter: false,
                 tableHeight: `${absoluteHeight}px`,
             }),
-            ...(fieldCell.cell.shape === FCellShapes.AUTOCOMPLETE && {
-                allowInconsistentValues: true,
-            }),
         };
 
         return (


### PR DESCRIPTION
Changed AllowInconsistentValues prop default in order to have the web standards default ACP behaviour