### PR TITLE
Fix/LS25001555 kup calendar

### DIFF
--- a/packages/ketchup/src/components/kup-calendar/kup-calendar.scss
+++ b/packages/ketchup/src/components/kup-calendar/kup-calendar.scss
@@ -206,6 +206,12 @@
     color: var(--kup_calendar_event_color);
   }
 
+  .fc-event {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem;
+  }
+
   .fc-event-main {
     color: inherit;
   }

--- a/packages/ketchup/src/components/kup-calendar/kup-calendar.scss
+++ b/packages/ketchup/src/components/kup-calendar/kup-calendar.scss
@@ -207,16 +207,15 @@
   }
 
   .fc-event {
-    display: flex;
-    justify-content: space-between;
     padding: 0.5rem;
   }
 
   .fc-event-main {
     color: inherit;
+    display: flex;
   }
 
-  .fc-event-title {
+  .fc-event-title .fc-event-time{
     padding: 0.25em;
   }
 

--- a/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
+++ b/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
@@ -314,6 +314,20 @@ export class KupCalendar {
                 minute: '2-digit',
             },
             eventDidMount: (info) => {
+                // In the calendar component, we handle two cases:
+                // if the '.fc-event-main' div exists, the event don't has start/end time;
+
+                const content = document.createElement('div');
+                const mainEvent = info.el.querySelector('.fc-event-main');
+                if (!mainEvent) {
+                    const title = info.el.querySelector('.fc-event-title');
+                    const time = info.el.querySelector('.fc-event-time');
+                    content.append(time, title);
+                    content.style.display = 'flex';
+                    content.style.flexDirection = 'column';
+                    info.el.appendChild(content);
+                }
+
                 if (this.iconCol) {
                     const row: KupDataRow = info.event.extendedProps.row;
                     const cell = row.cells[this.iconCol];
@@ -335,7 +349,9 @@ export class KupCalendar {
                         );
 
                         wrapper.appendChild(fImage);
-                        info.el.appendChild(wrapper);
+                        mainEvent
+                            ? mainEvent.appendChild(wrapper)
+                            : info.el.appendChild(wrapper);
                     }
                 }
 
@@ -367,19 +383,6 @@ export class KupCalendar {
                         });
                     }
                 }
-            },
-            eventContent: function (arg) {
-                const timeText = arg.timeText;
-                const title = arg.event.title;
-
-                return {
-                    html: `
-                    <div style="display: flex; flex-direction: column;">
-                      <div style="font-weight: bold;">${timeText}</div>
-                      <div>${title}</div>
-                    </div>
-                  `,
-                };
             },
             eventDrop: ({ event, oldEvent }) => {
                 this.kupCalendarEventDrop.emit({

--- a/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
+++ b/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
@@ -67,6 +67,7 @@ import { KupChipNode } from '../kup-chip/kup-chip-declarations';
 import { KupDebugCategory } from '../../managers/kup-debug/kup-debug-declarations';
 import { KupStore } from '../kup-state/kup-store';
 import { KupCalendarState } from './kup-calendar-state';
+import { FImageProps } from '../../f-components/f-image/f-image-declarations';
 
 @Component({
     tag: 'kup-calendar',
@@ -319,19 +320,21 @@ export class KupCalendar {
                     if (cell?.value) {
                         const wrapper = document.createElement('div');
                         wrapper.classList.add('icon-wrapper');
-                        cell.value.split(';').forEach((icon) => {
-                            if (icon) {
-                                const span = document.createElement('span');
-                                span.className = 'custom-icon';
-                                const path: string = getAssetPath(
-                                    `./assets/svg/${icon}.svg`
-                                );
-                                span.style.mask = `url('${path}') no-repeat center`;
-                                span.style.webkitMask = `url('${path}') no-repeat center`;
-                                wrapper.appendChild(span);
-                            }
-                        });
 
+                        const propsFImage: FImageProps = {
+                            resource: cell.value,
+                            placeholderResource: cell.placeholderIcon,
+                            sizeX: '1.5em',
+                            sizeY: '1.5em',
+                            wrapperClass: 'custom-icon',
+                        };
+
+                        const fImage = document.createElement('kup-image');
+                        Object.keys(propsFImage).forEach(
+                            (prop) => (fImage[prop] = propsFImage[prop])
+                        );
+
+                        wrapper.appendChild(fImage);
                         info.el.appendChild(wrapper);
                     }
                 }

--- a/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
+++ b/packages/ketchup/src/components/kup-calendar/kup-calendar.tsx
@@ -308,6 +308,10 @@ export class KupCalendar {
                     row: event.extendedProps.row,
                 });
             },
+            eventTimeFormat: {
+                hour: '2-digit',
+                minute: '2-digit',
+            },
             eventDidMount: (info) => {
                 if (this.iconCol) {
                     const row: KupDataRow = info.event.extendedProps.row;
@@ -360,6 +364,19 @@ export class KupCalendar {
                         });
                     }
                 }
+            },
+            eventContent: function (arg) {
+                const timeText = arg.timeText;
+                const title = arg.event.title;
+
+                return {
+                    html: `
+                    <div style="display: flex; flex-direction: column;">
+                      <div style="font-weight: bold;">${timeText}</div>
+                      <div>${title}</div>
+                    </div>
+                  `,
+                };
             },
             eventDrop: ({ event, oldEvent }) => {
                 this.kupCalendarEventDrop.emit({


### PR DESCRIPTION
Relative to `kup-calendar`:
- add `eventTimeFormat` for render `09:00` format like webup.jsf
- add custom card event 
- add `kup-image` for calendar event icon render
- now every event handle only one icon from cell