### PR TITLE
fix: section title

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -554,11 +554,6 @@ export class KupInputPanel {
             [`input-panel__commands--${this.buttonPosition}`]: true,
         };
 
-        const props: FTypographyProps = {
-            value: layout?.sections[0]?.title,
-            type: FTypographyType.HEADING1,
-        };
-
         return (
             <div>
                 <form
@@ -581,9 +576,14 @@ export class KupInputPanel {
                         }
                     }}
                 >
-                    <div class="input-panel__typography">
-                        <FTypography {...props} />
-                    </div>
+                    {layout?.sections.length == 1 && (
+                        <div class="input-panel__typography">
+                            <FTypography
+                                value={layout?.sections[0]?.title}
+                                type={FTypographyType.HEADING1}
+                            />
+                        </div>
+                    )}
                     <div class={classObj} style={styleObj}>
                         {rowContent}
                     </div>
@@ -1002,8 +1002,8 @@ export class KupInputPanel {
             +field.colSpan > 0
                 ? field.colSpan
                 : !(+field.colSpan > 0) && !(+field.colStart > 0)
-                ? 1
-                : null;
+                  ? 1
+                  : null;
 
         const colStart = colSpan ? `span ${colSpan}` : `${field.colStart}`;
 
@@ -1013,8 +1013,8 @@ export class KupInputPanel {
             +field.rowSpan > 0
                 ? field.rowSpan
                 : !(+field.rowSpan > 0) && !(+field.rowStart > 0)
-                ? 1
-                : null;
+                  ? 1
+                  : null;
 
         const rowStart = rowSpan ? `span ${rowSpan}` : `${field.rowStart}`;
 
@@ -1792,10 +1792,10 @@ export class KupInputPanel {
                     : cell.data?.data?.['kup-list'];
             if (kupListData) {
                 kupListData.data = filteredRows?.length
-                    ? this.#optionsTreeComboAdapter(
+                    ? (this.#optionsTreeComboAdapter(
                           visibleColumnsOptions,
                           cell.value
-                      ) ?? []
+                      ) ?? [])
                     : [];
                 kupListData.options = options.columns ?? [];
             } else {


### PR DESCRIPTION
Fixed section title behaviour. With 2 sections there were rendered a single title of the first section and 2 tabs. 
With this fix, it'll render a section title only if the sections length is equal to one