### PR TITLE
NC : fix : absolute inp height calculations with TBL

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel-utils.ts
@@ -1,3 +1,5 @@
+import { table } from 'console';
+import { FCell } from '../../f-components/f-cell/f-cell';
 import { FCellShapes } from '../../f-components/f-cell/f-cell-declarations';
 import {
     AbsoluteTblPositioningData,
@@ -94,20 +96,36 @@ export const getAbsoluteLeft = (col: number) => {
     return (col - 1) * 10 * LEFT_MULTIPLIER;
 };
 
-export const getInpComponentAbsoluteHeight = (layout: KupInputPanelLayout) => {
-    let inpRowHeight = 0;
-    layout.sections.forEach((section) => {
-        section.content.forEach((layoutField) => {
-            if (layoutField.absoluteRow > inpRowHeight) {
-                inpRowHeight =
-                    layoutField.absoluteRow +
-                    (layoutField.absoluteHeight > 1
-                        ? layoutField.absoluteHeight
-                        : 0);
-            }
-        });
-    });
-    return inpRowHeight;
+export const getInpComponentHeight = (layout: KupInputPanelLayout) => {
+    if (!layout) return 0;
+
+    const tblHeight =
+        layout.sections
+            .flatMap((section) => section.content)
+            .find((field) => field.shape === FCellShapes.TABLE)
+            ?.absoluteHeight ?? null;
+
+    const maxRow = Math.max(
+        0,
+        ...layout.sections.flatMap((section) =>
+            section.content.map(
+                // -1 because if the absolute height is 1 the sum will result in a field with height 2
+                // A field with absoluteRow 1 and height 1 is only on row 1, not 1+1
+                (field) => field.absoluteRow + (field.absoluteHeight - 1)
+            )
+        )
+    );
+
+    if (!tblHeight) {
+        // No TBL, all the rows have height 22
+        return maxRow * SPACED_ROW_HEIGHT;
+    } else {
+        // There is a TBL, with a rows height of 20
+        // All the non-TBL rows still have height 22
+        return (
+            (maxRow - tblHeight) * SPACED_ROW_HEIGHT + tblHeight * ROW_HEIGHT
+        );
+    }
 };
 
 export const graphicShapeHasIcon = (shape: string) => {

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -97,7 +97,7 @@ import {
     getAbsoluteLeft,
     getAbsoluteTop,
     getAbsoluteWidth,
-    getInpComponentAbsoluteHeight,
+    getInpComponentHeight,
     getLabelAbsoluteWidth,
     graphicShapeHasIcon,
     SPACED_ROW_HEIGHT,
@@ -496,11 +496,7 @@ export class KupInputPanel {
         } else {
             if (layout.absolute) {
                 rowContent = this.#renderAbsoluteLayout(inputPanelCell, layout);
-                // 12px is added due to the chance that the horizontal scrollbar will be rendered
-                styleObj.height = `${
-                    getInpComponentAbsoluteHeight(layout) * SPACED_ROW_HEIGHT +
-                    12
-                }px`;
+                styleObj.height = `${getInpComponentHeight(layout)}px`;
             } else {
                 if (!layout.sectionsType) {
                     const hasDim = layout.sections.some((sec) => sec.dim);


### PR DESCRIPTION
The absolute inp height calculation is now divided in 2 cases:
- With TBL: The rows of the TBL are now correctly considered as 20px, the remaining will be 22px as of before
- Without TBL: All the rows are considered 22px 

This avoids extra space when there is a tbl because her rows were considered of 22px as well, adding as much as 40 or 50 pixels of  extra empty space