### PR TITLE
TKIC391491: kup-data-table: fix error on merge columns, without smeupObject

### DIFF
--- a/packages/ketchup/src/managers/kup-data/kup-data.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data.ts
@@ -301,6 +301,7 @@ export class KupData {
          * @returns {boolean} if cell contain action showed on f-cell
          */
         hasActionCell: (cell: KupDataCell, commands: KupCommand[]): boolean => {
+            if (!cell || !cell.obj) return false;
             return commands.some((command) =>
                 this.cell.isActionCell(command, cell)
             );


### PR DESCRIPTION
This pull request includes a small but important change to the `KupData` class in the `kup-data.ts` file. The change ensures that the `hasActionCell` method checks if the `cell` or `cell.obj` is null or undefined before proceeding with further logic.

* [`packages/ketchup/src/managers/kup-data/kup-data.ts`](diffhunk://#diff-1134f1c58f69c8c58f677c4b837309662d336de988a6c488cd0063c2125fcb31R304): Added a null check for `cell` and `cell.obj` in the `hasActionCell` method to prevent potential errors.