### PR TITLE
TKIC391491: kup-data-table: fix management new column with formula, added in to visibleColumns list

### DIFF
--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-column-drop-menu.tsx
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-column-drop-menu.tsx
@@ -225,7 +225,7 @@ async function applyFormula(component: KupCard) {
             ? (parts[1].trim() as KupLanguageTotals)
             : valueString;
         if (premadeFormulas.includes(value)) {
-            dom.ketchup.data.column.new(
+            const result = dom.ketchup.data.column.new(
                 options.data,
                 KupDataNewColumnTypes.MATH,
                 {
@@ -240,7 +240,7 @@ async function applyFormula(component: KupCard) {
                 }
             );
             if (options.formulaCb !== undefined) {
-                options.formulaCb();
+                options.formulaCb(result);
             }
         } else {
             const result = dom.ketchup.data.column.new(
@@ -258,7 +258,7 @@ async function applyFormula(component: KupCard) {
                 combobox.data['kup-text-field'].helper = result as string;
                 combobox.refresh();
             } else if (options.formulaCb !== undefined) {
-                options.formulaCb();
+                options.formulaCb(result);
             }
         }
     }

--- a/packages/ketchup/src/components/kup-card/kup-card-declarations.ts
+++ b/packages/ketchup/src/components/kup-card/kup-card-declarations.ts
@@ -6,11 +6,6 @@ import {
     KupDataColumn,
     KupDataDataset,
 } from '../../managers/kup-data/kup-data-declarations';
-import { KupTextFieldEventPayload } from '../kup-text-field/kup-text-field-declarations';
-import {
-    KupButtonClickEventPayload,
-    KupTextFieldCustomEvent,
-} from '../../components';
 /**
  * Props of the kup-card component.
  * Used to export every prop in an object.
@@ -110,7 +105,7 @@ export interface KupCardColumnDropMenuOptions {
     enableMove: boolean;
     receivingColumn?: KupDataColumn;
     starterColumn?: KupDataColumn;
-    formulaCb?: () => void;
+    formulaCb?: (result: string | KupDataColumn) => void;
     mergeCb?: () => void;
     moveCb?: () => void;
 }

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -1710,37 +1710,7 @@ export class KupDataTable {
             type,
             options
         );
-        this.visibleColumns = this.getVisibleColumns().map((col) => col.name);
-        if (typeof result !== 'string') {
-            if (this.visibleColumns.findIndex((c) => c === result.name) < 0) {
-                this.#kupManager.debug.logMessage(
-                    this,
-                    'New column [' +
-                        result.name +
-                        '] not present in visibleColumns!',
-                    KupDebugCategory.WARNING
-                );
-                const previousColumnIndex = this.visibleColumns.findIndex(
-                    (c) => c == options.columns[1]
-                );
-                if (previousColumnIndex >= 0) {
-                    this.#kupManager.debug.logMessage(
-                        this,
-                        'New column [' +
-                            result.name +
-                            '] added in visibleColumns at index [' +
-                            (previousColumnIndex + 1) +
-                            ']!',
-                        KupDebugCategory.WARNING
-                    );
-                    this.visibleColumns.splice(
-                        previousColumnIndex + 1,
-                        0,
-                        result.name
-                    );
-                }
-            }
-        }
+        this.#insertNewColumnInVisibleColumnsList(result, options.columns[1]);
         this.refresh();
         return result;
     }
@@ -2086,6 +2056,43 @@ export class KupDataTable {
 
     //#endregion
 
+    #insertNewColumnInVisibleColumnsList(
+        result: string | KupDataColumn,
+        afterColumn: string
+    ) {
+        this.visibleColumns = this.getVisibleColumns().map((col) => col.name);
+        if (typeof result !== 'string') {
+            if (this.visibleColumns.findIndex((c) => c === result.name) < 0) {
+                this.#kupManager.debug.logMessage(
+                    this,
+                    'New column [' +
+                        result.name +
+                        '] not present in visibleColumns!',
+                    KupDebugCategory.WARNING
+                );
+                const previousColumnIndex = this.visibleColumns.findIndex(
+                    (c) => c == afterColumn
+                );
+                if (previousColumnIndex >= 0) {
+                    this.#kupManager.debug.logMessage(
+                        this,
+                        'New column [' +
+                            result.name +
+                            '] added in visibleColumns at index [' +
+                            (previousColumnIndex + 1) +
+                            ']!',
+                        KupDebugCategory.WARNING
+                    );
+                    this.visibleColumns.splice(
+                        previousColumnIndex + 1,
+                        0,
+                        result.name
+                    );
+                }
+            }
+        }
+    }
+
     #closeDropCard() {
         this.#kupManager.dynamicPosition.stop(
             this.#columnDropCard as KupDynamicPositionElement
@@ -2108,7 +2115,11 @@ export class KupDataTable {
                 enableMove: this.enableSortableColumns,
                 receivingColumn: receiving,
                 starterColumn: starter,
-                formulaCb: () => {
+                formulaCb: (result) => {
+                    this.#insertNewColumnInVisibleColumnsList(
+                        result,
+                        starter.name
+                    );
                     this.#closeDropCard();
                     this.refresh();
                 },


### PR DESCRIPTION
This pull request includes several changes to the `kup-card` and `kup-data-table` components in the `packages/ketchup` directory. The most important changes focus on improving the handling of new columns and the callback functions used in the `kup-card` component.

### Improvements to `kup-card` component:

* [`packages/ketchup/src/components/kup-card/built-in/kup-card-column-drop-menu.tsx`](diffhunk://#diff-7166541362960452374dbd430b23bc6fa0c5eaab5d245a78c5611ddf38f95307L228-R228): Modified the `applyFormula` function to pass the `result` parameter to the `formulaCb` callback function. [[1]](diffhunk://#diff-7166541362960452374dbd430b23bc6fa0c5eaab5d245a78c5611ddf38f95307L228-R228) [[2]](diffhunk://#diff-7166541362960452374dbd430b23bc6fa0c5eaab5d245a78c5611ddf38f95307L243-R243) [[3]](diffhunk://#diff-7166541362960452374dbd430b23bc6fa0c5eaab5d245a78c5611ddf38f95307L261-R261)
* [`packages/ketchup/src/components/kup-card/kup-card-declarations.ts`](diffhunk://#diff-dbc3dc5725e6d2b5744bae1b24edc8caa55937dd96f1ddfda294ac15cf76245eL113-R108): Updated the `KupCardColumnDropMenuOptions` interface to include the `result` parameter in the `formulaCb` callback function.

### Code cleanup:

* [`packages/ketchup/src/components/kup-card/kup-card-declarations.ts`](diffhunk://#diff-dbc3dc5725e6d2b5744bae1b24edc8caa55937dd96f1ddfda294ac15cf76245eL9-L13): Removed unused imports from the file.

### Improvements to `kup-data-table` component:

* [`packages/ketchup/src/components/kup-data-table/kup-data-table.tsx`](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584L1713-R1713): Refactored the logic for inserting new columns into the visible columns list into a separate private method `#insertNewColumnInVisibleColumnsList`. [[1]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584L1713-R1713) [[2]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R2059-R2095)
* [`packages/ketchup/src/components/kup-data-table/kup-data-table.tsx`](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584L2111-R2122): Updated the `formulaCb` callback function to use the new private method for inserting new columns.