### PR TITLE
 LS25001706: kup-accordion: fix re-calculate selectedItems on data change

### DIFF
--- a/packages/ketchup/src/components/kup-accordion/kup-accordion.tsx
+++ b/packages/ketchup/src/components/kup-accordion/kup-accordion.tsx
@@ -274,6 +274,19 @@ export class KupAccordion {
         }
     }
 
+    @Watch('data')
+    updateSelectedItems() {
+        const ids: string[] = [];
+        if (this.data?.length) {
+            for (let i = 0; i < this.data.length; i++) {
+                const node = this.data[i];
+                if (node.contentVisible) {
+                    ids.push(node.id);
+                }
+            }
+        }
+        this.selectedItems = ids;
+    }
     /*-------------------------------------------------*/
     /*           P u b l i c   M e t h o d s           */
     /*-------------------------------------------------*/
@@ -363,17 +376,6 @@ export class KupAccordion {
     /*-------------------------------------------------*/
     /*           P r i v a t e   M e t h o d s         */
     /*-------------------------------------------------*/
-
-    private updateSelectedItems() {
-        const ids: string[] = [];
-        for (let i = 0; i < this.data.length; i++) {
-            const node = this.data[i];
-            if (node.contentVisible) {
-                ids.push(node.id);
-            }
-        }
-        this.selectedItems = ids;
-    }
 
     private isItemExpandible(itemName: string): boolean {
         return this.slotsNames.includes(itemName);


### PR DESCRIPTION
This pull request refactors the `KupAccordion` component by moving the `updateSelectedItems` method from a private method to a public method decorated with the `@Watch` decorator. This change enables the method to automatically respond to changes in the `data` property.

### Refactoring of `KupAccordion` component:

* [`packages/ketchup/src/components/kup-accordion/kup-accordion.tsx`](diffhunk://#diff-418e5907b135be4f47d7a511c4014520f2f060e8c91c868b49c6ef320b082919R277-R289): The `updateSelectedItems` method is now decorated with `@Watch('data')`, allowing it to be triggered whenever the `data` property changes. This makes the method reactive to updates in `data`.
* [`packages/ketchup/src/components/kup-accordion/kup-accordion.tsx`](diffhunk://#diff-418e5907b135be4f47d7a511c4014520f2f060e8c91c868b49c6ef320b082919L367-L377): Removed the private `updateSelectedItems` method, as it has been replaced with the reactive public version.