### PR TITLE
LS25001762: kup-card: Performance optimizations

### DIFF
--- a/packages/ketchup/src/components/kup-card/kup-card-helper.tsx
+++ b/packages/ketchup/src/components/kup-card/kup-card-helper.tsx
@@ -16,14 +16,20 @@ import { KupChipNode } from '../kup-chip/kup-chip-declarations';
  * This function returns a list of components.
  * @param {GenericObject[]} compArray - Components' props.
  * @param {string} compType - Components' type.
+ * @param {number} maxLength - Maximum number of components to return.
  * @returns {JSX.Element[]} List of components.
  */
 export function compList(
     compArray: GenericObject[] | string[] | HTMLElement[],
-    compType: string
+    compType: string,
+    maxLength: number = compArray.length
 ): VNode[] {
     let list: VNode[] = [];
-    for (let index = 0; index < compArray.length; index++) {
+    for (
+        let index = 0;
+        index < Math.min(maxLength, compArray.length);
+        index++
+    ) {
         if (
             typeof compArray[0] !== 'string' &&
             !(compArray as GenericObject[])[index].id

--- a/packages/ketchup/src/components/kup-card/standard/kup-card-standard-12.scss
+++ b/packages/ketchup/src/components/kup-card/standard/kup-card-standard-12.scss
@@ -41,4 +41,14 @@
       margin-right: auto;
     }
   }
+
+  .sub-filters-warning {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--kup-space-05);
+
+    label {
+      font-size: var(--kup-label-01-font-size, 12px);
+    }
+  }
 }

--- a/packages/ketchup/src/components/kup-card/standard/kup-card-standard-14.scss
+++ b/packages/ketchup/src/components/kup-card/standard/kup-card-standard-14.scss
@@ -137,6 +137,16 @@ $padding: 0.5em;
     }
   }
 
+  .sub-filters-warning {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--kup-space-05);
+
+    label {
+      font-size: var(--kup-label-01-font-size, 12px);
+    }
+  }
+
   .sub-formula {
     padding: 0.5em 0;
   }

--- a/packages/ketchup/src/components/kup-card/standard/kup-card-standard.tsx
+++ b/packages/ketchup/src/components/kup-card/standard/kup-card-standard.tsx
@@ -1,4 +1,4 @@
-import { h, VNode } from '@stencil/core';
+import { Fragment, h, VNode } from '@stencil/core';
 import type { KupCard } from '../kup-card';
 import type { GenericObject } from '../../../types/GenericTypes';
 import { FImage } from '../../../f-components/f-image/f-image';
@@ -16,8 +16,10 @@ import { KupThemeColorValues } from '../../../managers/kup-theme/kup-theme-decla
 import { KupDom } from '../../../managers/kup-manager/kup-manager-declarations';
 import { KupDropdownButton } from '../../kup-dropdown-button/kup-dropdown-button';
 import { FButtonStyling } from '../../../f-components/f-button/f-button-declarations';
+import { kupManagerInstance } from '../../../managers/kup-manager/kup-manager';
 
 const dom: KupDom = document.documentElement as KupDom;
+const kupManager = kupManagerInstance();
 
 /**
  * 1st standard card layout, inspired by Material Design.
@@ -852,6 +854,9 @@ export function create12(component: KupCard): VNode {
             buttonsIds.push(button['id']);
         }
     }
+
+    const filtersMaxLen: number = kupManager.perfTuning.data.filtersMaxLength;
+
     return (
         <div class={`standard-layout-${component.layoutNumber} `}>
             {buttonsIds.includes(KupColumnMenuIds.BUTTON_REMOVE) ||
@@ -904,9 +909,12 @@ export function create12(component: KupCard): VNode {
                     : null}
             </div>
             {checkboxArray.length > 0 ? (
-                <div class="section-3">
-                    {compList(checkboxArray, 'checkbox')}
-                </div>
+                <Fragment>
+                    {getFiltersWarningElement(checkboxArray, filtersMaxLen)}
+                    <div class="section-3">
+                        {compList(checkboxArray, 'checkbox', filtersMaxLen)}
+                    </div>
+                </Fragment>
             ) : null}
         </div>
     );
@@ -1040,6 +1048,8 @@ export function create14(component: KupCard): VNode {
     const tooltipText = dom.ketchup.language.translate(
         KupLanguageSearch.TOOLTIP
     );
+
+    const filtersMaxLen: number = kupManager.perfTuning.data.filtersMaxLength;
 
     return (
         <div class={`standard-layout-${component.layoutNumber} `}>
@@ -1177,9 +1187,19 @@ export function create14(component: KupCard): VNode {
                                 : null}
                         </div>
                         {checkboxArray.length > 0 ? (
-                            <div class="sub-checkbox">
-                                {compList(checkboxArray, 'checkbox')}
-                            </div>
+                            <Fragment>
+                                {getFiltersWarningElement(
+                                    checkboxArray,
+                                    filtersMaxLen
+                                )}
+                                <div class="sub-checkbox">
+                                    {compList(
+                                        checkboxArray,
+                                        'checkbox',
+                                        filtersMaxLen
+                                    )}
+                                </div>
+                            </Fragment>
                         ) : null}
                     </div>
                 ) : null}
@@ -1620,4 +1640,19 @@ export function create17(component: KupCard): VNode {
             </div>
         </div>
     );
+}
+
+function getFiltersWarningElement(
+    checkboxArray: GenericObject[],
+    filtersMaxLength: number
+): VNode {
+    return checkboxArray.length > filtersMaxLength ? (
+        <div class={'sub-filters-warning'}>
+            <label>
+                {kupManager.language.translate(
+                    KupLanguageGeneric.PARTIAL_FILTERS_LIST
+                )}
+            </label>
+        </div>
+    ) : null;
 }

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -195,6 +195,7 @@ import { KupList } from '../kup-list/kup-list';
 import { KupDropdownButtonEventPayload } from '../kup-dropdown-button/kup-dropdown-button-declarations';
 import { FObjectFieldEventPayload } from '../../f-components/f-object-field/f-object-field-declarations';
 import { KupPerfTuningPriority } from '../../managers/kup-perf-tuning/kup-perf-tuning-declarations';
+import { max } from 'dayjs';
 
 const dom: KupDom = document.documentElement as KupDom;
 @Component({
@@ -952,29 +953,16 @@ export class KupDataTable {
     computeMaxRowsPerPage() {
         if (this.data?.columns?.length > 0 && this.data?.rows?.length > 0) {
             const columnsNumber = this.data.columns.length;
-            const perfTuningData = this.#kupManager.perfTuning.data;
+            const rowsNumber = this.data.rows.length;
+            const perfTuning = this.#kupManager.perfTuning;
 
-            switch (perfTuningData.priority) {
-                case KupPerfTuningPriority.ROWS_PER_PAGE:
-                    this.#maxRowsPerPage = perfTuningData.maxRowsPerPage;
-                    break;
-
-                case KupPerfTuningPriority.CELLS_PER_PAGE:
-                    const cellsNumber = this.data.rows.reduce(
-                        (acc, r) => acc + Object.keys(r.cells).length,
-                        0
-                    );
-                    const maxCellsNumberPerPage =
-                        perfTuningData.maxCellsPerPage;
-                    if (cellsNumber > maxCellsNumberPerPage) {
-                        // Rounds a number up to the nearest multiple of ten.
-                        this.#maxRowsPerPage =
-                            Math.ceil(
-                                maxCellsNumberPerPage / columnsNumber / 10
-                            ) * 10;
-                    }
-                    break;
-            }
+            perfTuning.maxRowsPerPageProvider(
+                columnsNumber,
+                rowsNumber,
+                (maxRows) => {
+                    this.#maxRowsPerPage = maxRows;
+                }
+            );
 
             if (this.rowsPerPage > this.#maxRowsPerPage)
                 this.rowsPerPage = this.#maxRowsPerPage;

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -194,8 +194,6 @@ import { KupColumnMenuIds } from '../../utils/kup-column-menu/kup-column-menu-de
 import { KupList } from '../kup-list/kup-list';
 import { KupDropdownButtonEventPayload } from '../kup-dropdown-button/kup-dropdown-button-declarations';
 import { FObjectFieldEventPayload } from '../../f-components/f-object-field/f-object-field-declarations';
-import { KupPerfTuningPriority } from '../../managers/kup-perf-tuning/kup-perf-tuning-declarations';
-import { max } from 'dayjs';
 
 const dom: KupDom = document.documentElement as KupDom;
 @Component({

--- a/packages/ketchup/src/managers/kup-language/kup-language-declarations.ts
+++ b/packages/ketchup/src/managers/kup-language/kup-language-declarations.ts
@@ -184,6 +184,7 @@ export enum KupLanguageGeneric {
     UPLOAD = 'genericUpload',
     CHOOSE = 'genericChoose',
     TYPE_CODE_OR_DESCR = 'genericTypeCodeOrDescr',
+    PARTIAL_FILTERS_LIST = 'genericPartialFiltersList',
 }
 /**
  * Grid decodes (data table customization settings).

--- a/packages/ketchup/src/managers/kup-language/languages.json
+++ b/packages/ketchup/src/managers/kup-language/languages.json
@@ -257,7 +257,8 @@
             "genericUpload": "Upload",
             "genericChoose": "Choose",
             "fileUploadSuccess": "Upload complete",
-            "genericTypeCodeOrDescr": "Type code or description"
+            "genericTypeCodeOrDescr": "Type code or description",
+            "genericPartialFiltersList": "Partial filters list"
         }
     },
     "french": {
@@ -518,7 +519,8 @@
             "genericUpload": "Carica",
             "genericChoose": "Scegli",
             "fileUploadSuccess": "Caricamento completato",
-            "genericTypeCodeOrDescr": "Digita codice o descrizione"
+            "genericTypeCodeOrDescr": "Digita codice o descrizione",
+            "genericPartialFiltersList": "Lista filtri parziale"
         },
         "variants": {
             "smeup": {

--- a/packages/ketchup/src/managers/kup-manager/kup-manager.ts
+++ b/packages/ketchup/src/managers/kup-manager/kup-manager.ts
@@ -204,9 +204,10 @@ export class KupManager {
             tooltipModal
         );
         this.perfTuning = new KupPerfTuning({
-            maxCellsPerPage: Number.MAX_VALUE,
+            maxCellsPerPage: 25000,
             maxRowsPerPage: 1000,
-            priority: KupPerfTuningPriority.ROWS_PER_PAGE,
+            filtersMaxLength: 200,
+            priority: KupPerfTuningPriority.DYNAMIC_ROWS_PER_PAGE,
         });
         this.perfMonitoring = new KupPerfMonitoring();
         document.addEventListener('pointerdown', (e) => {

--- a/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning-declarations.ts
+++ b/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning-declarations.ts
@@ -1,10 +1,12 @@
 export interface KupPerfTuningData {
     maxCellsPerPage: number;
     maxRowsPerPage: number;
+    filtersMaxLength: number;
     priority: KupPerfTuningPriority;
 }
 
 export enum KupPerfTuningPriority {
     CELLS_PER_PAGE = 'cells-per-page',
     ROWS_PER_PAGE = 'rows-per-page',
+    DYNAMIC_ROWS_PER_PAGE = 'dynamic-rows-per-page',
 }

--- a/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning.ts
+++ b/packages/ketchup/src/managers/kup-perf-tuning/kup-perf-tuning.ts
@@ -1,4 +1,8 @@
-import { KupPerfTuningData } from './kup-perf-tuning-declarations';
+import { number } from 'echarts';
+import {
+    KupPerfTuningData,
+    KupPerfTuningPriority,
+} from './kup-perf-tuning-declarations';
 
 export class KupPerfTuning {
     data: KupPerfTuningData;
@@ -30,5 +34,37 @@ export class KupPerfTuning {
         console.log(
             `perfIndex ${perfIndex}, maxCellsPerPage ${this.data.maxCellsPerPage}`
         );
+    }
+
+    maxRowsPerPageProvider(
+        columnsNumber: number,
+        rowsNumber: number,
+        maxRowsConsumer: (maxRows: number) => void
+    ): void {
+        switch (this.data.priority) {
+            case KupPerfTuningPriority.ROWS_PER_PAGE:
+                maxRowsConsumer(this.data.maxRowsPerPage);
+                break;
+
+            case KupPerfTuningPriority.CELLS_PER_PAGE:
+                computeRowCount(this.data.maxCellsPerPage);
+                break;
+            case KupPerfTuningPriority.DYNAMIC_ROWS_PER_PAGE:
+                if (columnsNumber <= 25) {
+                    maxRowsConsumer(this.data.maxRowsPerPage);
+                } else {
+                    computeRowCount(this.data.maxCellsPerPage);
+                }
+        }
+
+        function computeRowCount(maxCellsNumberPerPage: number) {
+            const cellsNumber = columnsNumber * rowsNumber;
+            if (cellsNumber > maxCellsNumberPerPage) {
+                // Rounds a number up to the nearest multiple of ten.
+                maxRowsConsumer(
+                    Math.ceil(maxCellsNumberPerPage / columnsNumber / 10) * 10
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
- It will be displayed the first 200 checkboxes when opening the filtering card.
- Changed the logic to compute the maximum number of cells per page: if the number of columns is lower than 25, 1000 rows will be displayed; otherwise, (25000/columns) cells will be displayed.