### PR TITLE
LS25001851: kup-autocomplete/kup-combobox: Improved UX

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -688,6 +688,7 @@ export class KupAutocomplete {
             showMarker: this.showMarker,
             legacyLook: this.legacyLook,
             size: getSizeOfInputElement(this.data, this.displayMode, this.size),
+            title: this.displayedValue ?? '',
         };
         const fullHeight =
             this.rootElement.classList.contains('kup-full-height');

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -617,6 +617,7 @@ export class KupCombobox {
             showMarker: this.showMarker,
             legacyLook: this.legacyLook,
             size: getSizeOfInputElement(this.data, this.displayMode, this.size),
+            title: this.displayedValue ?? '',
         };
         const fullHeight: boolean =
             this.rootElement.classList.contains('kup-full-height');


### PR DESCRIPTION
Set the title attribute to match the displayed value so that, when the displayed value exceeds the field length, the user can view the full description by hovering the mouse over the field.