### PR TITLE
kup-echart: fix automatic resize management, made it safer

### DIFF
--- a/packages/ketchup/src/components/kup-echart/kup-echart.tsx
+++ b/packages/ketchup/src/components/kup-echart/kup-echart.tsx
@@ -214,15 +214,13 @@ export class KupEchart {
     async resizeCallback(): Promise<void> {
         window.clearTimeout(this.#resizeTimeout);
         this.#resizeTimeout = window.setTimeout(() => {
-            if (this.#chartEl) {
+            if (this.#chartEl && this.#chartEl.getZr()) {
                 const xMin = this.rootElement.clientWidth - 5;
                 const xMax = this.rootElement.clientWidth + 5;
                 const yMin = this.rootElement.clientHeight - 5;
                 const yMax = this.rootElement.clientHeight + 5;
-                const x =
-                    this.data?.rows?.length > 0 ? this.#chartEl.getWidth() : 0;
-                const y =
-                    this.data?.rows?.length > 0 ? this.#chartEl.getHeight() : 0;
+                const x = this.#chartEl.getWidth();
+                const y = this.#chartEl.getHeight();
                 if (x < xMin || x > xMax || y < yMin || y > yMax) {
                     this.#chartEl.resize();
                 }
@@ -1948,7 +1946,7 @@ export class KupEchart {
     }
 
     disconnectedCallback() {
-        this.#chartEl.dispose();
+        this.#chartEl?.dispose();
         this.#kupManager.theme.unregister(this);
         this.#kupManager.resize.unobserve(this.rootElement);
     }


### PR DESCRIPTION
This pull request makes updates to the `KupEchart` class in `kup-echart.tsx` to improve error handling and ensure proper resizing behavior. The changes focus on adding null checks and simplifying conditional logic.

### Improvements to error handling:

* Updated the `disconnectedCallback` method to use optional chaining (`?.`) when calling `dispose` on `this.#chartEl`, preventing potential runtime errors if `#chartEl` is null or undefined.

### Enhancements to resizing logic:

* Modified the `resizeCallback` method to add a null check for `this.#chartEl.getZr()` before performing operations, ensuring the chart element is fully initialized. Simplified the logic for calculating `x` and `y` by removing unnecessary conditional checks.