### PR TITLE
feat/LS25001944: ACP and CMB onKupClearIconClick

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -378,6 +378,19 @@ export class KupAutocomplete {
         });
     }
 
+    onKupClearIconClick() {
+        this.value = '';
+        this.displayedValue = '';
+        this.#textfieldEl.value = '';
+        this.kupChange.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+            node: { value: '' },
+        });
+        this.#closeList();
+    }
     /*-------------------------------------------------*/
     /*                  W a t c h e r s                */
     /*-------------------------------------------------*/
@@ -739,6 +752,7 @@ export class KupAutocomplete {
                             );
                         }}
                         onIconClick={() => this.onKupIconClick()}
+                        onClearIconClick={() => this.onKupClearIconClick()}
                     ></FTextField>
                 </div>
                 {this.#prepList()}

--- a/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
+++ b/packages/ketchup/src/components/kup-combobox/kup-combobox.tsx
@@ -322,6 +322,20 @@ export class KupCombobox {
         });
     }
 
+    onKupClearIconClick() {
+        this.value = '';
+        this.displayedValue = '';
+        this.#textfieldEl.value = '';
+        this.kupChange.emit({
+            comp: this,
+            id: this.rootElement.id,
+            value: this.value,
+            inputValue: this.#textfieldEl.value,
+            node: { value: '' },
+        });
+        this.#closeList();
+    }
+
     /*-------------------------------------------------*/
     /*                  W a t c h e r s                */
     /*-------------------------------------------------*/
@@ -657,6 +671,7 @@ export class KupCombobox {
                         onFocus={() => this.onKupFocus()}
                         onInput={() => this.onKupInput()}
                         onIconClick={() => this.onKupIconClick()}
+                        onClearIconClick={() => this.onKupClearIconClick()}
                     ></FTextField>
                 </div>
                 {this.#prepList()}

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -470,7 +470,7 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
                         <button onClick={props.onPlusClick}>{plusEl}</button>
                     </div>
                 )}
-                {props.isClearable ? (
+                {props.isClearable && props.value ? (
                     <span
                         class={`mdc-text-field__icon kup-icon ${KupThemeIconValues.CLEAR.replace(
                             '--',


### PR DESCRIPTION
- add clear icon logic on `kup-autocomplete` and `kup-combobox` 
- icon visibility depends on props `isClearable` and not empty value