### PR TITLE
fix: LS25002091 - added CSS attribute for text with \n

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -105,7 +105,7 @@
     .f-cell__content {
       margin: 0;
       overflow: hidden;
-
+      white-space: pre-wrap;
       > * {
         max-width: 100%;
         word-break: normal;


### PR DESCRIPTION
The problem was displaying strings with hidden characters \n (new line) in ticket boxes: the characters were ignored, so the text did not wrap. With the "white-space" attribute the problem is solved.