### PR TITLE
NC: kup-tab-bar: manage click on infoIcon and toolbarIcon only if thetab is selected

### DIFF
--- a/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx
+++ b/packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx
@@ -563,17 +563,20 @@ export class KupTabBar {
                             sizeX="16px"
                             sizeY="16px"
                             onClick={async (event: MouseEvent) => {
-                                event.stopPropagation();
-                                const el = event.currentTarget as HTMLElement;
-                                const data = await this.infoCallback();
-                                this.infoState = data;
-                                if (this.infoState.length > 0) {
-                                    this.onKupInfoIconClick(el);
-                                } else {
-                                    this.kupManager.debug.logMessage(
-                                        this,
-                                        'InfoIcon data is empty, not opening dropdown.'
-                                    );
+                                if (node.active) {
+                                    event.stopPropagation();
+                                    const el =
+                                        event.currentTarget as HTMLElement;
+                                    const data = await this.infoCallback();
+                                    this.infoState = data;
+                                    if (this.infoState.length > 0) {
+                                        this.onKupInfoIconClick(el);
+                                    } else {
+                                        this.kupManager.debug.logMessage(
+                                            this,
+                                            'InfoIcon data is empty, not opening dropdown.'
+                                        );
+                                    }
                                 }
                             }}
                             wrapperClass="tab__iconToolbar iconInfo"
@@ -585,17 +588,20 @@ export class KupTabBar {
                             sizeX="16px"
                             sizeY="16px"
                             onClick={async (event: MouseEvent) => {
-                                event.stopPropagation();
-                                const el = event.currentTarget as HTMLElement;
-                                const data = await this.toolbarCallback();
-                                this.toolbarState = data;
-                                if (this.toolbarState.length > 0) {
-                                    this.onKupIconClick(el);
-                                } else {
-                                    this.kupManager.debug.logMessage(
-                                        this,
-                                        'Toolbar data is empty, not opening dropdown.'
-                                    );
+                                if (node.active) {
+                                    event.stopPropagation();
+                                    const el =
+                                        event.currentTarget as HTMLElement;
+                                    const data = await this.toolbarCallback();
+                                    this.toolbarState = data;
+                                    if (this.toolbarState.length > 0) {
+                                        this.onKupIconClick(el);
+                                    } else {
+                                        this.kupManager.debug.logMessage(
+                                            this,
+                                            'Toolbar data is empty, not opening dropdown.'
+                                        );
+                                    }
                                 }
                             }}
                             wrapperClass="tab__iconToolbar iconToolbar"


### PR DESCRIPTION

This pull request introduces a conditional check to ensure that certain event handlers in the `KupTabBar` component only execute if the `node.active` property is true. This change prevents unnecessary operations when the node is inactive.

### Enhancements to event handling in `KupTabBar`:

* Added a conditional `if (node.active)` check to the `onClick` handler for the info icon to ensure that the event processing and dropdown logic are only executed when the node is active. (`packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx`, [[1]](diffhunk://#diff-0277b131220664583a4ba46d75c1e236cf7a26163f839ef22c118f5aea9688b1R566-R569) [[2]](diffhunk://#diff-0277b131220664583a4ba46d75c1e236cf7a26163f839ef22c118f5aea9688b1R580)
* Added a similar `if (node.active)` check to the `onClick` handler for the toolbar icon, applying the same safeguard to the toolbar dropdown logic. (`packages/ketchup/src/components/kup-tab-bar/kup-tab-bar.tsx`, [[1]](diffhunk://#diff-0277b131220664583a4ba46d75c1e236cf7a26163f839ef22c118f5aea9688b1R591-R594) [[2]](diffhunk://#diff-0277b131220664583a4ba46d75c1e236cf7a26163f839ef22c118f5aea9688b1R605)