### PR TITLE
Feat/LS25002105 filter on chips kup data table

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -1763,7 +1763,7 @@ export namespace Components {
           * Opens the column menu of the given column.
           * @param column - Name of the column.
          */
-        "openColumnMenu": (column: string) => Promise<void>;
+        "openColumnMenu": (columnName: string, wrapperClass: string) => Promise<void>;
         /**
           * Current selected page set on component load
          */

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -7166,11 +7166,31 @@ export class KupDataTable {
                 const props: FChipsProps = {
                     data: chipsData,
                     id: 'group-chips',
-                    type: FChipType.INPUT,
                     onIconClick: [],
+                    onClearFilterClick: [],
+                    type: FChipType.INPUT,
                     onContextMenu: [],
+                    hasFilter: [],
                 };
                 for (let i = 0; i < chipsData.length; i++) {
+                    const column = getColumnByName(
+                        this.getColumns(),
+                        chipsData[i].id
+                    );
+                    const hasFilterColumn =
+                        this.#filtersColumnMenuInstance.hasFiltersForColumn(
+                            this.filters,
+                            column
+                        );
+                    props.hasFilter.push(hasFilterColumn);
+                    this.#filtersColumnMenuInstance.hasFiltersForColumn(
+                        this.filters,
+                        column
+                    );
+                    props.onClearFilterClick.push(() =>
+                        this.#onRemoveFilter(column)
+                    );
+
                     props.onIconClick.push(() => this.#removeGroup(i));
                     props.onContextMenu.push((chipArg, e) => {
                         this.#handleChipsContextMenu(chipArg.id, e);

--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -347,15 +347,16 @@ Type: `Promise<string | KupDataColumn>`
 
 Returns the new column created or a string containing the error message if something went wrong.
 
-### `openColumnMenu(column: string) => Promise<void>`
+### `openColumnMenu(columnName: string, wrapperClass: string) => Promise<void>`
 
 Opens the column menu of the given column.
 
 #### Parameters
 
-| Name     | Type     | Description           |
-| -------- | -------- | --------------------- |
-| `column` | `string` | - Name of the column. |
+| Name           | Type     | Description |
+| -------------- | -------- | ----------- |
+| `columnName`   | `string` |             |
+| `wrapperClass` | `string` |             |
 
 #### Returns
 

--- a/packages/ketchup/src/components/kup-tree/kup-tree.tsx
+++ b/packages/ketchup/src/components/kup-tree/kup-tree.tsx
@@ -786,7 +786,7 @@ export class KupTree {
             getColumnByName(this.getVisibleColumns(), column)
         );
         this.columnMenuInstance.open(this, column);
-        this.columnMenuInstance.reposition(this, this.columnMenuCard);
+        this.columnMenuInstance.reposition(this, this.columnMenuCard, 'th[data-column="' + column + '"]');
         this.kupTreeColumnMenu.emit({
             comp: this,
             id: this.rootElement.id,

--- a/packages/ketchup/src/f-components/f-chip/f-chip-declarations.ts
+++ b/packages/ketchup/src/f-components/f-chip/f-chip-declarations.ts
@@ -11,8 +11,10 @@ export interface FChipsProps extends FComponent {
     onClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
     onContextMenu?: ((chip: KupChipNode, e: PointerEvent) => void)[];
     onExpansionClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
+    onClearFilterClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
     onFocus?: ((chip: KupChipNode, e: FocusEvent) => void)[];
     onIconClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
+    hasFilter?: boolean [];
     primary?: boolean;
     sizing?: FChipSize;
     styling?: FChipStyling;
@@ -31,6 +33,7 @@ export enum FChipType {
     CHOICE = 'choice',
     FILTER = 'filter',
     INPUT = 'input',
+    // HAS_FILTER = 'has-filter',
     STANDARD = 'standard',
 }
 /**

--- a/packages/ketchup/src/f-components/f-chip/f-chip-declarations.ts
+++ b/packages/ketchup/src/f-components/f-chip/f-chip-declarations.ts
@@ -9,6 +9,7 @@ export interface FChipsProps extends FComponent {
     displayMode?: ItemsDisplayMode;
     onBlur?: ((chip: KupChipNode, e: FocusEvent) => void)[];
     onClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
+    onContextMenu?: ((chip: KupChipNode, e: PointerEvent) => void)[];
     onExpansionClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];
     onFocus?: ((chip: KupChipNode, e: FocusEvent) => void)[];
     onIconClick?: ((chip: KupChipNode, e: PointerEvent) => void)[];

--- a/packages/ketchup/src/f-components/f-chip/f-chip.tsx
+++ b/packages/ketchup/src/f-components/f-chip/f-chip.tsx
@@ -252,6 +252,26 @@ function createChipList(
                             <span class="chip__text">{chipText}</span>
                         </span>
                     </span>
+                    {props.hasFilter?.[i] && (
+                        <span role="gridcell">
+                            <span
+                                tabindex="-1"
+                                class={`kup-icon chip__icon ${KupThemeIconValues.FILTER_REMOVE.replace(
+                                    '--',
+                                    ''
+                                )}`}
+                                onClick={
+                                    props.onClearFilterClick &&
+                                    props.onClearFilterClick[i]
+                                        ? props.onClearFilterClick[i].bind(
+                                              props.onClearFilterClick[i],
+                                              chip
+                                          )
+                                        : null
+                                }
+                            ></span>
+                        </span>
+                    )}
                     {isInput ? (
                         <span role="gridcell">
                             <span

--- a/packages/ketchup/src/f-components/f-chip/f-chip.tsx
+++ b/packages/ketchup/src/f-components/f-chip/f-chip.tsx
@@ -153,7 +153,7 @@ function createChipList(
             const onlyIcon = !!(chip.icon && !chip.value);
             let componentClass: string = `chip ${
                 onlyIcon ? 'chip--only-icon' : ''
-            } ${disabled && 'chip--disabled'}`;
+            } ${disabled ? 'chip--disabled' : ''}`;
             let iconEl = [];
             let iconClass = 'chip__icon chip__icon--leading';
 

--- a/packages/ketchup/src/f-components/f-chip/f-chip.tsx
+++ b/packages/ketchup/src/f-components/f-chip/f-chip.tsx
@@ -211,6 +211,14 @@ function createChipList(
                             ? props.onClick[i].bind(props.onClick[i], chip)
                             : null
                     }
+                    onContextMenu={
+                        props.onContextMenu && props.onContextMenu[i]
+                            ? props.onContextMenu[i].bind(
+                                  props.onContextMenu[i],
+                                  chip
+                              )
+                            : null
+                    }
                     role="row"
                     title={chip.title ? chip.title : ''}
                 >

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -79,16 +79,15 @@ export class KupColumnMenu {
         );
     }
     /**
-     * Function called to reposition the column menu card to the appropriate column.
+     * Function called to reposition the column menu card to the appropriate selector.
      * @param {KupDataTable | KupTree} comp - Component using the column menu.
      */
-    reposition(comp: KupDataTable | KupTree, card: HTMLKupCardElement): void {
+    reposition(comp: KupDataTable | KupTree, card: HTMLKupCardElement, wrapperSelector:string): void {
         const root: ShadowRoot = comp.rootElement.shadowRoot;
         if (root) {
             if (card) {
-                const column: string = card.dataset.column;
                 const wrapper: HTMLElement = root.querySelector(
-                    'th[data-column="' + column + '"]'
+                    wrapperSelector
                 );
                 if (dom.ketchup.dynamicPosition.isRegistered(card as any)) {
                     dom.ketchup.dynamicPosition.changeAnchor(


### PR DESCRIPTION
- Updated the `f-chip` component to support new props that allow rendering a filter icon and assigning a callback for its click event.
- Enhanced the `kup-data-table` component to handle the updated `f-chip`. Now filters can be activated via right-click on the chip, and once active, a filter icon is shown. Clicking the icon removes the applied filters.