### PR TITLE
LS25002312: kup-autocomplete: enter event management, without stop propagation

### DIFF
--- a/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
+++ b/packages/ketchup/src/components/kup-autocomplete/kup-autocomplete.tsx
@@ -461,8 +461,6 @@ export class KupAutocomplete {
                     this.#listEl.focusPrevious();
                     break;
                 case 'Enter':
-                    e.preventDefault();
-                    e.stopPropagation();
                     this.onKupChangeSubmit(
                         this.#textfieldEl.value,
                         this.kupSubmit


### PR DESCRIPTION
This pull request includes a small change to the `kup-autocomplete.tsx` file. The change removes the prevention of default behavior and event propagation when the 'Enter' key is pressed in the `KupAutocomplete` component.