### PR TITLE
LS25002454: kup-input-panel - Changed default fields visibility, field will be hidden only when column.visible is equals to false

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -490,7 +490,7 @@ export class KupInputPanel {
 
         if (!layout?.sections?.length) {
             rowContent = inputPanelCell.cells
-                .filter(({ column }) => column.visible)
+                .filter(({ column }) => column.visible !== false)
                 .map((cell) =>
                     this.#renderCell(cell.cell, inputPanelCell.row, cell.column)
                 );
@@ -1023,12 +1023,21 @@ export class KupInputPanel {
         );
     }
 
+    #skipRenderField(fieldCell: {
+        cell: KupDataCell;
+        column: KupDataColumn;
+    }): boolean {
+        return (
+            !fieldCell || !fieldCell.cell || fieldCell.column.visible === false
+        );
+    }
+
     #renderField(cells: InputPanelCells, field: KupInputPanelLayoutField) {
         const fieldCell = cells.cells.find(
             (cell) => cell.column.name === field.id
         );
 
-        if (!fieldCell || !fieldCell.cell || !fieldCell.column.visible) {
+        if (this.#skipRenderField(fieldCell)) {
             return;
         }
 
@@ -1078,7 +1087,7 @@ export class KupInputPanel {
             (cell) => cell.column.name === field.id
         );
 
-        if (!fieldCell || !fieldCell.cell || !fieldCell.column.visible) {
+        if (this.#skipRenderField(fieldCell)) {
             return;
         }
 
@@ -1797,26 +1806,31 @@ export class KupInputPanel {
         ).then((options) => {
             const visibleColumns: string[] =
                 options?.columns
-                    ?.filter((col) => col?.visible || !('visible' in col))
-                    .map((col) => col.name) || [];
+                    ?.filter(
+                        (col: KupDataColumn) =>
+                            col?.visible !== false || !('visible' in col)
+                    )
+                    .map((col: KupDataColumn) => col.name) || [];
 
-            const filteredRows: KupDataRow[] = options?.rows?.map((row) => {
-                const { cells } = row;
-                const filteredCells = visibleColumns.reduce(
-                    (acc, columnName) => {
-                        if (row.cells.hasOwnProperty(columnName)) {
-                            acc[columnName] = cells[columnName];
-                        }
-                        return acc;
-                    },
-                    {}
-                );
+            const filteredRows: KupDataRow[] = options?.rows?.map(
+                (row: KupDataRow) => {
+                    const { cells } = row;
+                    const filteredCells = visibleColumns.reduce(
+                        (acc, columnName) => {
+                            if (row.cells.hasOwnProperty(columnName)) {
+                                acc[columnName] = cells[columnName];
+                            }
+                            return acc;
+                        },
+                        {}
+                    );
 
-                return {
-                    ...row,
-                    cells: filteredCells,
-                };
-            });
+                    return {
+                        ...row,
+                        cells: filteredCells,
+                    };
+                }
+            );
 
             const visibleColumnsOptions = { ...options, rows: filteredRows };
 


### PR DESCRIPTION
This pull request refines the visibility logic for handling columns and cells in the `KupInputPanel` component. The changes ensure that visibility checks are more explicit and reusable, improving code clarity and maintainability.

### Enhancements to visibility logic:

* Updated the filter condition in `rowContent` to explicitly check `column.visible !== false`, ensuring clarity in visibility checks. (`packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx`, [packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsxL493-R493](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L493-R493))
* Introduced a private helper method `#skipRenderField` to centralize and simplify visibility checks for fields, replacing repetitive logic in multiple places. (`packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx`, [[1]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751R1026-R1040) [[2]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L1081-R1090)

### Improvements to column and row filtering:

* Adjusted the column filtering logic to explicitly handle cases where `visible` is `false` or not defined, ensuring consistent behavior. (`packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx`, [packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsxL1800-R1816](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L1800-R1816))
* Refactored the row filtering logic to align with the updated column visibility checks, improving code readability and consistency. (`packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx`, [packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsxL1819-R1833](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L1819-R1833))