### PR TITLE
fix: TED style update

### DIFF
--- a/packages/ketchup/src/components/kup-editor/kup-editor.tsx
+++ b/packages/ketchup/src/components/kup-editor/kup-editor.tsx
@@ -626,7 +626,11 @@ export class KupEditor {
                                     (e.target as HTMLTextAreaElement).value
                                 )
                             }
+                            placeholder="Type your text here..."
                             readOnly={this.isReadOnly}
+                            style={{
+                                height: this.editorHeight || 'auto',
+                            }}
                             class="kup-editor-textarea"
                         ></textarea>
                     )}

--- a/packages/ketchup/src/managers/kup-theme/kup-theme-application.scss
+++ b/packages/ketchup/src/managers/kup-theme/kup-theme-application.scss
@@ -2438,9 +2438,8 @@ Please note that using !important should generally be avoided if possible, as it
 kup-editor[initial-edit-type='text'] {
   .kup-editor-textarea {
     width: 100%;
-    padding: 0;
     border: 0;
-    padding: 1em;
+    padding: 16px 25px 0px 25px;
     box-sizing: border-box;
     font-family: var(--kup-font-family);
     outline: none;


### PR DESCRIPTION
This pull request introduces enhancements to the `kup-editor` component in the `ketchup` package, focusing on improving user experience and visual styling. The key changes include adding a placeholder to the text area, dynamically setting its height, and updating the padding in the associated SCSS file.

### Enhancements to `kup-editor` functionality:
* [`packages/ketchup/src/components/kup-editor/kup-editor.tsx`](diffhunk://#diff-b3b9c985ca61d2b64280dac8fadef2dbda530ecdeabdc3e1c91ee03cdf7abc83R629-R633): Added a placeholder with the text "Type your text here..." to the text area and introduced a dynamic height style based on the `editorHeight` property.

### Styling improvements:
* [`packages/ketchup/src/managers/kup-theme/kup-theme-application.scss`](diffhunk://#diff-0d117788568cfbf8274942e4b58932c6a6b58eaa754ec00b74e5420f0704697eL2441-R2442): Updated the padding for the `.kup-editor-textarea` element to `16px 25px 0px 25px` for better spacing and alignment.