### PR TITLE
NC: commented modifications done for INP editable fields dimensioning by cell data

### DIFF
--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -263,14 +263,14 @@ export const CMBandACPAdapter = (
     value: string,
     label: string,
     options: GenericObject,
-    cellData: GenericObject
+    _cellData: GenericObject
 ) => ({
     data: {
         'kup-text-field': {
             trailingIcon: true,
             label,
-            size: cellData?.size,
-            maxLength: cellData?.maxLength,
+            // size: _cellData?.size,
+            // maxLength: _cellData?.maxLength,
         },
         'kup-list': {
             showIcons: true,


### PR DESCRIPTION
This pull request makes a minor change to `CMBandACPAdapter` in `cell-utils.ts`. The change renames the `cellData` parameter to `_cellData` and comments out its usage in the `kup-text-field` configuration. 

- [`packages/ketchup/src/utils/cell-utils.ts`](diffhunk://#diff-cac10ccedbfb19cc7c17fc8dfd3fc0ec91ca968569e2aac9c6352f170c2ef547L266-R273): Renamed the `cellData` parameter to `_cellData` and commented out its usage for `size` and `maxLength` in the `kup-text-field` object.