### PR TITLE
LS25002590 fix: custom color

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -1150,7 +1150,10 @@ function setCell(
                     cell.value
                 );
                 const cellValue = getCellValueForDisplay(column, cell);
-                if (cellValueNumber < 0) {
+                const hasCustomColor = Boolean(
+                    cell.style && cell.style['color']
+                );
+                if (!hasCustomColor && cellValueNumber < 0) {
                     classObj[FCellClasses.TEXT_DANGER] = true;
                 }
                 if (isAutoCentered(props)) {


### PR DESCRIPTION
fix: apply danger text only when there isn't a custom color coming from backend