### PR TITLE
LS25002793: fix: sort and filter on invalid values

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -5709,7 +5709,9 @@ export class KupDataTable {
                     this.#footer[column.name] != null
                         ? getValueForDisplay(
                               this.#footer[column.name],
-                              column.obj,
+                              dom.ketchup.objects.isDate(column.obj)
+                                  ? column.obj
+                                  : { t: 'NR', p: '', k: '' },
                               column.decimals
                           )
                         : '';

--- a/packages/ketchup/src/components/kup-tree/kup-tree.tsx
+++ b/packages/ketchup/src/components/kup-tree/kup-tree.tsx
@@ -84,7 +84,10 @@ import { KupCardEventPayload } from '../kup-card/kup-card-declarations';
 import { componentWrapperId } from '../../variables/GenericVariables';
 import { KupThemeIconValues } from '../../managers/kup-theme/kup-theme-declarations';
 import { KupPointerEventTypes } from '../../managers/kup-interact/kup-interact-declarations';
-import { KupManagerClickCb } from '../../managers/kup-manager/kup-manager-declarations';
+import {
+    KupDom,
+    KupManagerClickCb,
+} from '../../managers/kup-manager/kup-manager-declarations';
 import {
     FCellClasses,
     FCellEventPayload,
@@ -102,6 +105,8 @@ import { KupDebugCategory } from '../../managers/kup-debug/kup-debug-declaration
 import { FTextFieldMDC } from '../../f-components/f-text-field/f-text-field-mdc';
 import { FImage } from '../../f-components/f-image/f-image';
 import { isExpandable } from './kup-tree-helper';
+
+const dom: KupDom = document.documentElement as KupDom;
 @Component({
     tag: 'kup-tree',
     styleUrl: 'kup-tree.scss',
@@ -786,7 +791,11 @@ export class KupTree {
             getColumnByName(this.getVisibleColumns(), column)
         );
         this.columnMenuInstance.open(this, column);
-        this.columnMenuInstance.reposition(this, this.columnMenuCard, 'th[data-column="' + column + '"]');
+        this.columnMenuInstance.reposition(
+            this,
+            this.columnMenuCard,
+            'th[data-column="' + column + '"]'
+        );
         this.kupTreeColumnMenu.emit({
             comp: this,
             id: this.rootElement.id,
@@ -1965,7 +1974,9 @@ export class KupTree {
                     this.footer[column.name] != null
                         ? getValueForDisplay(
                               this.footer[column.name],
-                              column.obj,
+                              dom.ketchup.objects.isDate(column.obj)
+                                  ? column.obj
+                                  : { t: 'NR', p: '', k: '' },
                               column.decimals
                           )
                         : '';

--- a/packages/ketchup/src/managers/kup-dates/kup-dates.ts
+++ b/packages/ketchup/src/managers/kup-dates/kup-dates.ts
@@ -165,7 +165,7 @@ export class KupDates {
      * @param {dayjs.ConfigType} input - Date to be formatted.
      * @param {string} format - Output format.
      * @see https://day.js.org/docs/en/display/format
-     */
+     **/
     format(input: dayjs.ConfigType, format?: string): string {
         if (!format) {
             format = 'L'; // MM/DD/YYYY, DD/MM/YYYY depending on locale
@@ -311,12 +311,9 @@ export class KupDates {
      * @param {string} format - Format of the input date.
      * @returns {Date} Date object.
      */
-    toDate(input: dayjs.ConfigType, format?: string): Date {
-        if (format && format != null) {
-            return dayjs.utc(input, format).toDate();
-        } else {
-            return dayjs.utc(input).toDate();
-        }
+    toDate(input: dayjs.ConfigType, format?: string): Date | null {
+        const parsed = format ? dayjs.utc(input, format) : dayjs.utc(input);
+        return parsed.isValid() ? parsed.toDate() : null;
     }
     /**
      * Converts the input in a Dayjs object.

--- a/packages/ketchup/src/managers/kup-objects/kup-objects.ts
+++ b/packages/ketchup/src/managers/kup-objects/kup-objects.ts
@@ -129,7 +129,7 @@ export class KupObjects {
      */
     isDate(obj: KupObj): boolean {
         if (!obj) return false;
-        return 'D8' === obj.t;
+        return 'D8' === obj.t && !obj.p.includes('*UP');
     }
     /**
      * Checks whether the object represents an icon or not.

--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -188,28 +188,40 @@ export function compareValues(
         v1 = dom.ketchup.math.numberifySafe(s1);
         v2 = dom.ketchup.math.numberifySafe(s2);
     } else if (dom.ketchup.objects.isDate(obj1)) {
-        v1 = dom.ketchup.dates.toDate(
+        const firstDateValue = dom.ketchup.dates.toDate(
             dom.ketchup.dates.format(s1, KupDatesFormats.ISO_DATE)
         );
-        v2 = dom.ketchup.dates.toDate(
+        const secondDateValue = dom.ketchup.dates.toDate(
             dom.ketchup.dates.format(s2, KupDatesFormats.ISO_DATE)
         );
+        if (firstDateValue && secondDateValue) {
+            v1 = firstDateValue;
+            v2 = secondDateValue;
+        }
     } else if (dom.ketchup.objects.isTime(obj1)) {
         // Previous code could not work because dayjs
         // returns an invalid date when it tries to parse a time
         // This solution is simpler and it works because the time format
         // was assumed to be equals to HH:mm:ss or HH:mm
-        v1 = Number(s1.replace(/:/g, ''));
-        v2 = Number(s2.replace(/:/g, ''));
+        const firstTimeValue = Number(s1.replace(/:/g, ''));
+        const secondTimeValue = Number(s2.replace(/:/g, ''));
+        if (!Number.isNaN(firstTimeValue) && !Number.isNaN(secondTimeValue)) {
+            v1 = firstTimeValue;
+            v2 = secondTimeValue;
+        }
     } else if (dom.ketchup.objects.isTimestamp(obj1)) {
-        v1 = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s1, KupDatesFormats.ISO_DATE_TIME),
+        const firstTimestampValue = dom.ketchup.dates.toDate(
+            dom.ketchup.dates.format(s1, KupDatesFormats.ISO_DATE),
             KupDatesFormats.ISO_DATE_TIME
         );
-        v2 = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s2, KupDatesFormats.ISO_DATE_TIME),
+        const secondTimestampValue = dom.ketchup.dates.toDate(
+            dom.ketchup.dates.format(s2, KupDatesFormats.ISO_DATE),
             KupDatesFormats.ISO_DATE_TIME
         );
+        if (firstTimestampValue && secondTimestampValue) {
+            v1 = firstTimestampValue;
+            v2 = secondTimestampValue;
+        }
     }
     if (v1 > v2) {
         return sm * 1;

--- a/packages/ketchup/src/utils/filters/filters.ts
+++ b/packages/ketchup/src/utils/filters/filters.ts
@@ -344,10 +344,11 @@ export class Filters {
                         filterMatch;
 
                     // Try to convert the filter value to a Date
-                    if (dom.ketchup.dates.isValidFormattedStringDate(dateStr)) {
-                        const filterDate = dom.ketchup.dates.toDate(
-                            this.normalizeValue(dateStr, obj)
-                        );
+                    const filterDate = dom.ketchup.dates.toDate(
+                        this.normalizeValue(dateStr, obj),
+                        defaultFormat
+                    );
+                    if (filterDate) {
                         checkByRegularExpression = false;
 
                         switch (operator) {
@@ -386,7 +387,10 @@ export class Filters {
                         dom.ketchup.objects.isTimeWithSeconds(obj)
                     )
                 ) {
-                    value = dom.ketchup.dates.format(value);
+                    const formattedValue = dom.ketchup.dates.format(value);
+                    if (formattedValue !== 'Invalid Date') {
+                        value = formattedValue;
+                    }
                 }
             }
 


### PR DESCRIPTION
- Exclude invalid *UP dates from being converted to Date objects
- Ensure that values with failed conversions in sort and filter are treated as strings
- Time and timestamp totals are now displayed in the correct format