### PR TITLE
Fixed the calculation of the maximum number of rows and made the visibleColumns prop publicly accessible.

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts
@@ -79,6 +79,7 @@ export enum KupDataTableProps {
     transpose = 'Transposes the data of the data table.',
     updatableData = 'When set to true, editable cells will be rendered using input components and update button will appair below the matrix',
     updateOnClick = 'When set to true, editable checkbox will call update',
+    visibleColumns = 'Defines the columns that are visible in the table',
 }
 export interface KupDataTableDataset {
     columns?: KupDataColumn[];

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -949,9 +949,10 @@ export class KupDataTable {
     }
 
     @Watch('data')
+    @Watch('visibleColumns')
     computeMaxRowsPerPage() {
         if (this.data?.columns?.length > 0 && this.data?.rows?.length > 0) {
-            const columnsNumber = this.data.columns.length;
+            const columnsNumber = this.getVisibleColumns().length;
             const rowsNumber = this.data.rows.length;
             const perfTuning = this.#kupManager.perfTuning;
 


### PR DESCRIPTION
### Feature Addition: Visible Columns

* [`packages/ketchup/src/components/kup-data-table/kup-data-table-declarations.ts`](diffhunk://#diff-045a7ca2ec2339f929f9d1780d621227cd07fd0e8f16051dba5298eb987f7a90R82): Added a new property, `visibleColumns`, to the `KupDataTableProps` enum, which defines the columns that are visible in the table.

### Logic Update: Compute Rows Per Page

* [`packages/ketchup/src/components/kup-data-table/kup-data-table.tsx`](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R952-R955): Updated the `computeMaxRowsPerPage` method to consider only visible columns by using the `getVisibleColumns()` method. Additionally, added a `@Watch` decorator for the `visibleColumns` property to trigger updates when its value changes.