### PR TITLE
LS25002976: kup-box: fix visualization of IMAGE in box, if calculated by default

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -109,14 +109,6 @@ export const FCell: FunctionalComponent<FCellProps> = (
     const cellType = dom.ketchup.data.cell.getType(cell, shape);
     const sizing =
         props.density === 'extra_dense' ? 'extra-small' : cell.data?.sizing;
-    const subcomponentProps: unknown = {
-        ...cell.data,
-        ...(cell?.icon ? { resource: cell.icon } : {}),
-        ...(cell?.placeholderIcon
-            ? { placeholderResource: cell.placeholderIcon }
-            : {}),
-        ...(sizing ? { sizing } : {}),
-    };
 
     let cssClasses = cell.cssClass
         ? cell.cssClass
@@ -140,6 +132,15 @@ export const FCell: FunctionalComponent<FCellProps> = (
     if (!cell.data || Object.keys(cell.data).length === 0) {
         setDefaults(cellType, cell);
     }
+    const subcomponentProps: unknown = {
+        ...cell.data,
+        ...(cell?.icon ? { resource: cell.icon } : {}),
+        ...(cell?.placeholderIcon
+            ? { placeholderResource: cell.placeholderIcon }
+            : {}),
+        ...(sizing ? { sizing } : {}),
+    };
+
     if (isEditable && editableTypes.includes(cellType)) {
         cell.data.showMarker = cell.tooltip ?? false;
         content = setEditableCell(cellType, classObj, cell, column, props);


### PR DESCRIPTION

This pull request refactors the `FCell` component in `f-cell.tsx` to improve readability and maintainability by reorganizing the initialization of `subcomponentProps`. The most important change involves moving the creation of `subcomponentProps` closer to its usage, ensuring better logical flow within the function.

Refactoring for improved readability:

* [`packages/ketchup/src/f-components/f-cell/f-cell.tsx`](diffhunk://#diff-55bfd4938b15230a3efa7bec67f01ff04fac25d96e76de1a5584c7ed5801813eL112-L119): Moved the initialization of `subcomponentProps` from its earlier position to directly before its usage, aligning it with the logical flow of the function. [[1]](diffhunk://#diff-55bfd4938b15230a3efa7bec67f01ff04fac25d96e76de1a5584c7ed5801813eL112-L119) [[2]](diffhunk://#diff-55bfd4938b15230a3efa7bec67f01ff04fac25d96e76de1a5584c7ed5801813eR135-R143)