### PR TITLE
LS25002842: Options order

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -402,17 +402,18 @@ const MainRADAdapter = (
     cell?: KupDataCellOptions
 ) => {
     const newData = RADAdapter(currentValue, options);
-    return {
+    const value = {
         ...cell.data,
         ...newData,
-        data: Object.values(
-            Object.fromEntries(
+        data: Array.from(
+            new Map(
                 [...(cell.data?.data ?? []), ...(newData.data ?? [])].map(
                     (item) => [item.value, item]
                 )
-            )
+            ).values()
         ),
     };
+    return value;
 };
 
 const MainCMBandACPAdapter = (


### PR DESCRIPTION
Fixed adapter method to preserve options data order in radio button cell shape.