### PR TITLE
fix / new changes for size and descrMode for InputLegacy

### DIFF
--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -275,14 +275,14 @@ export const CMBandACPAdapter = (
     value: string,
     label: string,
     options: GenericObject,
-    _cellData: GenericObject
+    cellData: GenericObject
 ) => ({
     data: {
         'kup-text-field': {
             trailingIcon: true,
             label,
-            // size: _cellData?.size,
-            // maxLength: _cellData?.maxLength,
+            ...(cellData?.size && { size: cellData.size }),
+            ...(cellData?.maxLength && { maxLength: cellData.maxLength }),
         },
         'kup-list': {
             showIcons: true,


### PR DESCRIPTION
Corrections to some previous changes made for correct sizing of ACP fields if in InputLegacy in this PR:
https://github.com/smeup/ketchup/pull/2663

Now size and maxLength are not always added (with the risk of them being undefined), but only if they are found with a valid value.
This was very likely the issue that created problem with the previous release.

Also created a cycle before creating the kup-data-table in order to force the ACPs to have codeOnly in both descrMode and selectMode.

Executed the e2e:run command in webup.js and all tests are passing