### PR TITLE
fix/text area logic limited to TextField only

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -393,6 +393,7 @@ const MainITXAdapter = (
 ) => ({
     ...cell.data,
     label: fieldLabel,
+    ...(cell.data?.maxLength && { textArea: cell.data.maxLength >= 256 }),
 });
 
 const MainRADAdapter = (

--- a/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
+++ b/packages/ketchup/src/f-components/f-text-field/f-text-field.tsx
@@ -72,10 +72,6 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
     let minusEl: HTMLElement;
     let plusEl: HTMLElement;
 
-    if (props.maxLength >= 256) {
-        props.textArea = true;
-    }
-
     if (
         props.label &&
         !props.leadingLabel &&
@@ -200,7 +196,7 @@ function setContent(props: FTextFieldProps): HTMLDivElement {
     let value = props.value;
     let inputType = props.quantityButtons
         ? 'number'
-        : (props.inputType ?? 'text');
+        : props.inputType ?? 'text';
     let persManageForNumberFormat = false;
     if (props.inputType === 'number') {
         inputType = 'text';


### PR DESCRIPTION
This PR moves the textArea logic in the MainITXAdapter, in order to limit it only to the TextField (ITX) and not make the textArea appear on shapes such as ACP, AML, CMB...