### PR TITLE
feat / LS25003113 - EXU / delete action now triggers update

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
+++ b/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-main.scss
@@ -101,6 +101,14 @@
     --kup-fcell-padding-wide,
     var(--kup-space-04) var(--kup-space-03)
   );
+  --kup_datatable_inserted_row_background: var(
+    --kup-datatable-inserted-row-background,
+    #c8e6c9
+  );
+  --kup_datatable_modified_row_background: var(
+    --kup-datatable-modified-row-background,
+    #ffd8a6
+  );
 
   display: block;
   font-family: var(--kup_datatable_font_family);
@@ -439,6 +447,16 @@ tbody {
       }
     }
 
+    &.inserted {
+      td {
+        background-color: var(--kup_datatable_inserted_row_background);
+      }
+    }
+    &.modified {
+      td {
+        background-color: var(--kup_datatable_modified_row_background);
+      }
+    }
     &:hover:not(.group):not(.selected) {
       td {
         color: var(--kup_datatable_text_color_hover);


### PR DESCRIPTION
WARNING: this pr will break the actually present webupjs tests, a pr to fix those issues has been opened: [webupjs/1870](https://github.com/smeup/webup.js/pull/1870)

This PR changes the way EXU treats the click on the delete button.

Now instead of deleting the row only inside its data and confirming it with the submit button, the click directly triggers a kup-update event.
The payload is created to be identical to the payload created after an old delete and confirm process.

If only inserted AND NOT SUBMITTED rows are deleted there is no need to call an update. The method simply resort to the old deleteRows method

Added another small feature, a way to identify if a row has been inserted or modified:
- Inserted: green row background
- Modified: orange row background