### PR TITLE
minor-fix: LS25003270: f-label

### DIFF
--- a/packages/ketchup/src/f-components/f-label/f-label.tsx
+++ b/packages/ketchup/src/f-components/f-label/f-label.tsx
@@ -18,9 +18,11 @@ export const FLabel: FunctionalComponent<FLabelProps> = ({ text, classes }) => {
     const parsedElements = getParsedElements(text);
     // To avoid creating unnecessary span in the text
     // when there are no tags to format the content
-    if (parsedElements.find((p) => p.tag !== undefined)) {
-        return <span class={classes}>{getVNodes(parsedElements)}</span>;
-    } else {
-        return <Fragment>{text}</Fragment>;
-    }
+    return (
+        <span class={classes}>
+            {parsedElements.find((p) => p.tag !== undefined)
+                ? getVNodes(parsedElements)
+                : text}
+        </span>
+    );
 };


### PR DESCRIPTION
This PR introduces a small change to render all FLabel components as <span> elements instead of the default.
This adjustment is necessary because the surrounding fragment is a <div> with the class f-cell__content, not f-cell__text, which applies slightly different styles.