### PR TITLE
fix / LS25003404 / EXU insert with empty table now adds all the cells

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-helper.ts
@@ -1100,7 +1100,8 @@ function cloneRowGroup(group: KupDataTableRowGroup): KupDataTableRowGroup {
 export function getDiffData(
     originalData: KupDataDataset,
     modifiedData: KupDataDataset,
-    includesAlsoEmptyRows: boolean = false
+    includesAlsoEmptyRows: boolean = false,
+    insertedRowsIds: string[] = []
 ): KupDataDataset {
     const diffDataTable = {
         columns: modifiedData.columns.filter((col) => col.visible),
@@ -1108,6 +1109,11 @@ export function getDiffData(
     };
 
     for (const modifiedRow of modifiedData.rows) {
+        if (insertedRowsIds.includes(modifiedRow.id)) {
+            diffDataTable.rows.push(modifiedRow);
+            continue;
+        }
+
         const newRow = { cells: {}, id: modifiedRow.id };
 
         for (const column of diffDataTable.columns) {

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -4968,7 +4968,12 @@ export class KupDataTable {
             comp: this,
             id: this.rootElement.id,
             originalData: this.#originalDataLoaded,
-            updatedData: getDiffData(this.#originalDataLoaded, this.data, true),
+            updatedData: getDiffData(
+                this.#originalDataLoaded,
+                this.data,
+                true,
+                this.#insertedRowIds
+            ),
             command: command,
         });
     };
@@ -6948,14 +6953,25 @@ export class KupDataTable {
         const styling: FButtonStyling = FButtonStyling.FLAT;
 
         const createRowWithInputFields = (): KupDataRow => {
-            let row: KupDataRow = { cells: {} };
-            this.#originalDataLoaded?.columns.forEach((c) => {
-                (row.cells[c.name] as Omit<KupDataCell, 'value'>) = {
-                    shape: c.shape ?? FCellShapes.INPUT_FIELD,
+            const row: KupDataRow = { cells: {} };
+            this.data?.columns.forEach((c) => {
+                const cell: Partial<KupDataCell> = {
+                    shape: c.shape ?? FCellShapes.TEXT_FIELD,
                     obj: { ...c.obj },
-                    isEditable: true,
+                    isEditable: c.isEditable ?? true,
+                    data: {},
                 };
+
+                if (c['length'] && c['maxLength']) {
+                    cell.data = {
+                        size: c['length'],
+                        maxLength: c['maxLength'],
+                    };
+                }
+
+                row.cells[c.name] = cell as KupDataCell;
             });
+
             return row;
         };
 


### PR DESCRIPTION
## Description

This PR will make webupjs tests fail: fixed in this [PR](https://github.com/smeup/webup.js/pull/1927)

PR including changes regarding a new EXU insert mechanism, used to avoid problems when inserting a new row in an empty table:
- Keeping the graphic shapes, editability, size and maxLength of the column on insert
- When confirming the insert all the cells of the row are passed to webupjs and it's his responsibility to filter the ones that need to be sent to the *UPDATE service

The previous behaviour was to add only editable input fields cells even when editability was set to false or the shape was something other that an inputField

## Related to

LS25003404: correggere editabilità in nuova riga exu