### PR TITLE
kup-data-table: fix creating list of updated data, if not updatetable - use for "otherButtons"

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -4967,9 +4967,9 @@ export class KupDataTable {
         this.kupUpdate.emit({
             comp: this,
             id: this.rootElement.id,
-            originalData: this.#originalDataLoaded,
+            originalData: this.#originalDataLoaded ?? this.data,
             updatedData: getDiffData(
-                this.#originalDataLoaded,
+                this.#originalDataLoaded ?? this.data,
                 this.data,
                 true,
                 this.#insertedRowIds


### PR DESCRIPTION

This pull request makes a targeted fix to the `KupDataTable` component to improve its handling of the `originalData` property in emitted update events.

- Ensures that `originalData` falls back to the current `data` if `#originalDataLoaded` is undefined when emitting the `kupUpdate` event, preventing potential issues when the original data hasn't been loaded yet.