### PR TITLE
LS25003361: kup-chip: managed font size sizing too, when change "sizing" prop

### DIFF
--- a/packages/ketchup/src/components/kup-chip/kup-chip-declarations.ts
+++ b/packages/ketchup/src/components/kup-chip/kup-chip-declarations.ts
@@ -8,8 +8,13 @@ import { KupEventPayload } from '../../types/GenericTypes';
 export enum KupChipProps {
     customStyle = 'Custom style of the component.',
     data = 'List of elements.',
-    displayId = "When enabled, the chip's text will display both the id and the value.",
+    // displayId = "When enabled, the chip's text will display both the id and the value.",
+    disabled = 'When true, the chip cannot be edited, nor removed.',
+    displayMode = 'When enabled, the chip will display both the id and description of the data.',
     enableInput = "When enabled, it's possible to add items to the chip's dataset through an input slot (kup-autocomplete, kup-combobox, kup-text-field).",
+    label = 'When set, will be shown a label on the chips.',
+    sizing = 'The size of the chip. Available sizes: small, medium.',
+    styling = 'The style of the chip. Available styles: outlined, raised.',
     type = 'The type of chip. Available types: input, filter, choice or empty for default.',
 }
 

--- a/packages/ketchup/src/components/kup-chip/kup-chip.tsx
+++ b/packages/ketchup/src/components/kup-chip/kup-chip.tsx
@@ -64,20 +64,25 @@ export class KupChip {
      */
     @Prop({ mutable: true }) data: KupChipNode[] = [];
     /**
-     * When enabled, it's possible to add items to the chip's dataset through an input slot (kup-autocomplete, kup-combobox, kup-text-field).
-     * @default false
-     */
-    @Prop() enableInput = false;
-    /**
      * When true, the chip cannot be edited, nor removed.
      * @default false
      */
     @Prop() disabled: boolean = false;
     /**
-     * The type of chip. Available types: input, filter, choice or empty for default.
-     * @default FChipType.STANDARD
+     * When enabled, the chip's text will display both the id and description.
+     * @default ItemsDisplayMode.DESCRIPTION
      */
-    @Prop() type: FChipType = FChipType.STANDARD;
+    @Prop() displayMode: ItemsDisplayMode = ItemsDisplayMode.DESCRIPTION;
+    /**
+     * When enabled, it's possible to add items to the chip's dataset through an input slot (kup-autocomplete, kup-combobox, kup-text-field).
+     * @default false
+     */
+    @Prop() enableInput = false;
+    /**
+     * When set,will be shown a label on the chips
+     * @default null
+     */
+    @Prop() label: string = null;
     /**
      * Sets the size of the chip
      * @default FChipSize.SMALL
@@ -88,18 +93,12 @@ export class KupChip {
      * @default FChipStyling.RAISED
      */
     @Prop() styling: FChipStyling = FChipStyling.RAISED;
-
     /**
-     * When enabled, the chip's text will display both the id and description.
-     * @default ItemsDisplayMode.DESCRIPTION
+     * The type of chip. Available types: input, filter, choice or empty for default.
+     * @default FChipType.STANDARD
      */
-    @Prop() displayMode: ItemsDisplayMode = ItemsDisplayMode.DESCRIPTION;
+    @Prop() type: FChipType = FChipType.STANDARD;
 
-    /**
-     * When set,will be shown a label on the chips
-     * @default null
-     */
-    @Prop() label: string = null;
     /*-------------------------------------------------*/
     /*       I n t e r n a l   V a r i a b l e s       */
     /*-------------------------------------------------*/

--- a/packages/ketchup/src/f-components/f-chip/f-chip.scss
+++ b/packages/ketchup/src/f-components/f-chip/f-chip.scss
@@ -100,6 +100,7 @@
 
     &.chip--medium .chip-set__item .chip-set__wrapper .chip {
       height: var(--kup_chip_medium_height);
+      font-size: 1.2em;
     }
 
     &.chip--outlined .chip-set__item .chip-set__wrapper .chip {

--- a/packages/ketchup/src/f-components/f-chip/f-chip.tsx
+++ b/packages/ketchup/src/f-components/f-chip/f-chip.tsx
@@ -6,10 +6,7 @@ import {
 } from '../f-chip/f-chip-declarations';
 import { FImage } from '../f-image/f-image';
 import { FImageProps } from '../f-image/f-image-declarations';
-import {
-    KupThemeColorValues,
-    KupThemeIconValues,
-} from '../../managers/kup-theme/kup-theme-declarations';
+import { KupThemeIconValues } from '../../managers/kup-theme/kup-theme-declarations';
 import { KupChipNode } from '../../components/kup-chip/kup-chip-declarations';
 import { KupDom } from '../../managers/kup-manager/kup-manager-declarations';
 import { KupLanguageGeneric } from '../../managers/kup-language/kup-language-declarations';


### PR DESCRIPTION
This pull request introduces several new properties and updates to the `kup-chip` component, enhancing its configurability and display options. The changes include new props for controlling chip behavior and appearance, adjustments to the order and documentation of existing props, and a minor style update for medium-sized chips.

**Component property enhancements:**

* Added new properties to `KupChipProps` and the `KupChip` class: `disabled`, `displayMode`, `label`, `sizing`, and `styling`, allowing for more flexible chip configuration and display. (`kup-chip-declarations.ts`, `kup-chip.tsx`) [[1]](diffhunk://#diff-a5aeefae75c4e2cc6f173464bb98da7cd9854b297ba8c49cd34b5d01d99f3f89L11-R17) [[2]](diffhunk://#diff-0a9306aeed5bf3771f4c8c32d429e55b4be8296ae3a1ff03c9623990ca8bb584L67-R85)
* Updated prop documentation and order in `kup-chip.tsx` to improve clarity and maintain consistency, including moving and clarifying descriptions for `displayMode`, `label`, and `type`. [[1]](diffhunk://#diff-0a9306aeed5bf3771f4c8c32d429e55b4be8296ae3a1ff03c9623990ca8bb584L67-R85) [[2]](diffhunk://#diff-0a9306aeed5bf3771f4c8c32d429e55b4be8296ae3a1ff03c9623990ca8bb584L91-L102)

**Styling improvements:**

* Increased the font size for medium-sized chips in `f-chip.scss` for better readability.

**Code cleanup:**

* Removed the unused `KupThemeColorValues` import from `f-chip.tsx` for cleaner code.