### PR TITLE
LS25003542: Fix bar width calculation in f-image component

### DIFF
--- a/packages/ketchup/src/f-components/f-image/f-image.tsx
+++ b/packages/ketchup/src/f-components/f-image/f-image.tsx
@@ -195,7 +195,8 @@ function createBar(data: FImageData[]): HTMLDivElement {
             backgroundColor: data[i].color,
             left: leftProgression + '%',
             height: data[i].height,
-            width: data[i].width,
+            width:
+                Number(data[i].width.replace(/%$/, '')) - leftProgression + '%',
         };
 
         leftProgression += parseFloat(data[i].width);


### PR DESCRIPTION
Adjusts the width calculation for bars in the f-image component to account for left progression, ensuring correct rendering when using percentage widths.