### PR TITLE
NC: Fix: kup-file-upload

### DIFF
--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -2540,7 +2540,7 @@ export namespace Components {
         "customStyle": string;
         /**
           * Error string to render in component
-          * @default 'false'
+          * @default 'undefined'
          */
         "error": string;
         /**
@@ -8466,7 +8466,7 @@ declare namespace LocalJSX {
         "customStyle"?: string;
         /**
           * Error string to render in component
-          * @default 'false'
+          * @default 'undefined'
          */
         "error"?: string;
         "onKup-file-upload-change"?: (event: KupFileUploadCustomEvent<KupFileUploadChangeEventPayload>) => void;

--- a/packages/ketchup/src/components/kup-file-upload/kup-file-upload-declarations.ts
+++ b/packages/ketchup/src/components/kup-file-upload/kup-file-upload-declarations.ts
@@ -2,9 +2,12 @@ import { KupEventPayload } from '../../types/GenericTypes';
 
 export enum KupFileUploadProps {
     customStyle = 'Custom style of the component.',
+    error = 'Error string to render in component',
     pathString = 'The initial filepaths.',
     FupMul = 'Sets the multiple upload.',
     FupAut = 'Sets the auto upload of select file',
+    FupDir = 'Sets the custom dir to upload files',
+    FupAty = 'Sets the accepted extensions',
 }
 
 export interface KupFileUploadEventPayload extends KupEventPayload {

--- a/packages/ketchup/src/components/kup-file-upload/kup-file-upload.scss
+++ b/packages/ketchup/src/components/kup-file-upload/kup-file-upload.scss
@@ -24,6 +24,17 @@
     padding: 1em;
     position: relative;
 
+    &__invalid {
+      border-color: var(--kup-danger-color, #d32f2f);
+      background: rgba(211, 47, 47, 0.06);
+      box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.15) inset;
+      cursor: not-allowed;
+
+      & * {
+        opacity: 0.95;
+      }
+    }
+
     &__buttons {
       display: flex;
       gap: 1em;

--- a/packages/ketchup/src/components/kup-file-upload/kup-file-upload.tsx
+++ b/packages/ketchup/src/components/kup-file-upload/kup-file-upload.tsx
@@ -107,6 +107,7 @@ export class KupFileUpload {
     @State() autoUpload?: boolean = false;
     @State() acceptedFiles?: string[] = null;
     @State() isValidDropFiles?: boolean = true;
+    @State() fupError?: string = null;
 
     //#endregion
 
@@ -135,11 +136,18 @@ export class KupFileUpload {
     /*-------------------------------------------------*/
     /*                  W a t c h e r s                */
     /*-------------------------------------------------*/
+
+    @Watch('error')
+    onErrorChange() {
+        this.fupError = this.error;
+    }
+
     @Watch('pathString')
     onDataChanged() {
-        this.error = '';
+        this.fupError = '';
         this.#handleCancel();
-        this.pathFiles = this.#getArrayPathString(this.pathString);
+        this.pathFiles =
+            this.pathString?.split(';').filter((path) => path.trim()) || [];
     }
 
     @Watch('FupMul')
@@ -258,7 +266,7 @@ export class KupFileUpload {
     }
 
     #handleFileChange(event: Event) {
-        this.error = '';
+        this.fupError = '';
 
         const newFiles =
             Array.from((event.target as HTMLInputElement).files) || [];
@@ -273,7 +281,7 @@ export class KupFileUpload {
 
     #handleDrop(event: DragEvent) {
         event.preventDefault();
-        this.error = '';
+        this.fupError = '';
         this.isValidDropFiles = true;
         const droppedFiles = event.dataTransfer.files;
         if (droppedFiles?.length <= 0) {
@@ -352,10 +360,6 @@ export class KupFileUpload {
         this.setLoading(true);
     }
 
-    #getArrayPathString(paths: string): string[] {
-        return paths?.split(';').filter((path) => path.trim()) || [];
-    }
-
     #getUniqueFiles(files: File[]): File[] {
         const uniqueFiles = files.reduce((map, file) => {
             const key = `${file.name}-${file.size}-${file.lastModified}`;
@@ -407,7 +411,7 @@ export class KupFileUpload {
 
         if (!isValid) {
             // Set extension error
-            this.error = this.#kupManager.language.translate(
+            this.fupError = this.#kupManager.language.translate(
                 KupLanguageUpload.INVALID_EXTENSION
             );
         }
@@ -515,10 +519,10 @@ export class KupFileUpload {
                                 </Fragment>
                             )}
                         </div>
-                        {this.error && (
+                        {this.fupError && (
                             <div class="file-upload__error">
                                 <span class="mdc-error-message">
-                                    {this.error}
+                                    {this.fupError}
                                 </span>
                             </div>
                         )}

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1458,7 +1458,6 @@ export class KupInputPanel {
             [FCellTypes.TABLE, this.#DataTableAdapter.bind(this)],
             [FCellTypes.TIME, this.#TimeAdapter.bind(this)],
             [FCellTypes.IMAGE_LIST, this.#ImageListAdapter.bind(this)],
-            [FCellTypes.FILE_UPLOAD, this.#FileUploadAdapter.bind(this)],
         ]);
 
         const adapter = dataAdapterMap.get(cellType);
@@ -1741,18 +1740,6 @@ export class KupInputPanel {
             initialValue: currentValue || '',
             leadingLabel: fieldLabel || '',
             value: currentValue || '',
-        };
-    }
-
-    #FileUploadAdapter(
-        _options: GenericObject,
-        _fieldLabel: string,
-        currentValue: string,
-        cell: KupInputPanelCell
-    ) {
-        return {
-            pathString: currentValue,
-            ...cell.data,
         };
     }
 

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -322,6 +322,7 @@ const mapData = (cell: KupDataCellOptions, column: KupDataColumn) => {
         [FCellTypes.CHECKBOX, MainCHKAdapter.bind(this)],
         [FCellTypes.OBJECT, MainObjectAdapter.bind(this)],
         [FCellTypes.CHIP, MainCHIAdapter.bind(this)],
+        [FCellTypes.FILE_UPLOAD, MainFUPAdapter.bind(this)],
     ]);
 
     const adapter = dataAdapterMap.get(cellType);
@@ -445,6 +446,18 @@ const MainCMBandACPAdapter = (
             ...cell.data,
         };
     }
+};
+
+export const MainFUPAdapter = (
+    _options: GenericObject,
+    _fieldLabel: string,
+    currentValue: string,
+    cell: KupInputPanelCell
+) => {
+    return {
+        ...cell.data,
+        pathString: currentValue,
+    };
 };
 
 const optionsTreeComboAdapter = (options: any, currentValue: string) => {

--- a/packages/ketchup/src/managers/kup-language/kup-language-declarations.ts
+++ b/packages/ketchup/src/managers/kup-language/kup-language-declarations.ts
@@ -254,4 +254,5 @@ export enum KupLanguageTotals {
  */
 export enum KupLanguageUpload {
     SUCCESS = 'fileUploadSuccess',
+    INVALID_EXTENSION = 'invalidExtension',
 }

--- a/packages/ketchup/src/managers/kup-language/languages.json
+++ b/packages/ketchup/src/managers/kup-language/languages.json
@@ -257,6 +257,7 @@
             "genericUpload": "Upload",
             "genericChoose": "Choose",
             "fileUploadSuccess": "Upload complete",
+            "invalidExtension": "Invalid extension",
             "genericTypeCodeOrDescr": "Type code or description",
             "genericPartialFiltersList": "Partial filters list"
         }
@@ -519,6 +520,7 @@
             "genericUpload": "Carica",
             "genericChoose": "Scegli",
             "fileUploadSuccess": "Caricamento completato",
+            "invalidExtension": "Estensione non valida",
             "genericTypeCodeOrDescr": "Digita codice o descrizione",
             "genericPartialFiltersList": "Lista filtri parziale"
         },


### PR DESCRIPTION
- Prevent adding multiple temporary files when multi-file mode is disabled
- Prevent duplicate file uploads
- Fix `pathString` prop update
- Enable automatic upload on drag-and-drop in auto-upload mode
- Add file extension validation on drop
- Restrict multiple file drops when multi-file mode is disabled