### PR TITLE
LS25003042: f-image: safe management create element

### DIFF
--- a/packages/ketchup/src/f-components/f-image/f-image.tsx
+++ b/packages/ketchup/src/f-components/f-image/f-image.tsx
@@ -127,24 +127,28 @@ function createImage(props: FImageProps): HTMLImageElement {
             class={props.placeholderResource ? HIDDEN_CLASS : ''}
             onLoad={(e) => {
                 const img = e.currentTarget as HTMLImageElement;
-                const placeholder = img.parentElement.querySelector(
-                    '.f-image__placeholder'
-                );
-                const iconWrapper =
-                    img.parentElement.querySelector('.iconWrapper');
+                if (img && img.parentElement) {
+                    const placeholder = img.parentElement.querySelector(
+                        '.f-image__placeholder'
+                    );
+                    const iconWrapper =
+                        img.parentElement.querySelector('.iconWrapper');
 
-                const fWrapper =
-                    img.parentElement.parentElement.querySelector('.f-image');
-                if (props.onLoad) {
-                    props.onLoad(e);
-                }
-                if (placeholder) {
-                    placeholder.classList.add(HIDDEN_CLASS);
-                    img.classList.remove(HIDDEN_CLASS);
-                }
-                if (iconWrapper) {
-                    iconWrapper.classList.add(HIDDEN_CLASS);
-                    fWrapper.classList.add('noIcon');
+                    const fWrapper =
+                        img.parentElement.parentElement.querySelector(
+                            '.f-image'
+                        );
+                    if (props.onLoad) {
+                        props.onLoad(e);
+                    }
+                    if (placeholder) {
+                        placeholder.classList.add(HIDDEN_CLASS);
+                        img.classList.remove(HIDDEN_CLASS);
+                    }
+                    if (iconWrapper) {
+                        iconWrapper.classList.add(HIDDEN_CLASS);
+                        fWrapper.classList.add('noIcon');
+                    }
                 }
             }}
             onError={(e) => {


### PR DESCRIPTION
This pull request makes a minor update to the `createImage` function in `f-image.tsx` to improve robustness when handling the `onLoad` event. The main change ensures that DOM queries and manipulations are only attempted if the image and its parent element exist, preventing potential runtime errors.

- Added a check to confirm that `img` and its `parentElement` exist before querying for and manipulating DOM elements in the `onLoad` handler. [[1]](diffhunk://#diff-73e55fc3c2c0c0e168c1b7ef0f9792f42f8c1d55991e90178fab582cf0670e7aR130-R140) [[2]](diffhunk://#diff-73e55fc3c2c0c0e168c1b7ef0f9792f42f8c1d55991e90178fab582cf0670e7aR152)