### PR TITLE
fix/LS25002489/kup-button in kup htm

### DIFF
--- a/packages/ketchup/src/components/kup-htm/kup-htm.scss
+++ b/packages/ketchup/src/components/kup-htm/kup-htm.scss
@@ -8,9 +8,6 @@
   height: 100%;
   .kup-htm.is-link {
     height: 100%;
-    a {
-      float: left;
-    }
     iframe {
       min-height: 600px;
       width: 100%;

--- a/packages/ketchup/src/components/kup-htm/kup-htm.tsx
+++ b/packages/ketchup/src/components/kup-htm/kup-htm.tsx
@@ -19,12 +19,15 @@ import { componentWrapperId } from '../../variables/GenericVariables';
 import {
     GenericObject,
     KupComponent,
+    KupComponentSizing,
     KupEventPayload,
 } from '../../types/GenericTypes';
 import { getProps, setProps } from '../../utils/utils';
 import { KupHTMProps } from './kup-htm-declarations';
 import { KupLanguageGeneric } from '../../managers/kup-language/kup-language-declarations';
 import { KupObj } from '../../managers/kup-objects/kup-objects-declarations';
+import { FImage } from '../../f-components/f-image/f-image';
+import { FButtonStyling } from '../../components';
 
 @Component({
     tag: 'kup-htm',
@@ -148,15 +151,19 @@ export class KupHTM {
                     <div class={`kup-htm ${isLink ? 'is-link' : ''}`}>
                         {isLink ? (
                             <Fragment>
-                                <a
-                                    href={this.data.value}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    {this.#kupManager.language.translate(
+                                <kup-button
+                                    label={this.#kupManager.language.translate(
                                         KupLanguageGeneric.OPEN_IN_NEW_TAB
                                     )}
-                                </a>
+                                    sizing={'small' as KupComponentSizing}
+                                    class={'kup-secondary'}
+                                    icon="open-in-new"
+                                    styling={'flat' as FButtonStyling}
+                                    trailingIcon={true}
+                                    onClick={() =>
+                                        this.openInNewTab(this.data.value)
+                                    }
+                                ></kup-button>
                                 <iframe
                                     src={this.data.value}
                                     frameBorder="0"
@@ -170,6 +177,10 @@ export class KupHTM {
             </Host>
         );
     }
+
+    openInNewTab = (url: string) => {
+        window.open(url, '_blank', 'noopener,noreferrer');
+    };
 
     disconnectedCallback() {
         this.#kupManager.theme.unregister(this);


### PR DESCRIPTION
Due to the simplicity of use and its better aspect with zero effort, the a href in kup-htm has been changed with a kup-button doing the same thing.
Functionality remains the same