### PR TITLE
LS25003572: Fix column menu chips

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/readme.md
+++ b/packages/ketchup/src/components/kup-data-table/readme.md
@@ -491,6 +491,23 @@ Type: `Promise<void>`
 
 
 
+### `toggleTotalsMatrix(columnName?: string, calculateTotals?: boolean) => Promise<void>`
+
+
+
+#### Parameters
+
+| Name              | Type      | Description |
+| ----------------- | --------- | ----------- |
+| `columnName`      | `string`  |             |
+| `calculateTotals` | `boolean` |             |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `tooltipRequest() => Promise<void>`
 
 This method is used to force tooltip request for current focused cell

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -357,12 +357,25 @@ export class KupColumnMenu {
                         KupDebugCategory.ERROR
                     );
                 }
-                chipData.push({
-                    icon: child.icon ? child.icon : null,
-                    value: childColumn ? childColumn.title : '*Not found!',
-                    obj: child.obj ? child.obj : null,
-                    id: childColumn ? childColumn.name : '*NOTFND',
-                });
+
+                if (childColumn) {
+                    if (childColumn.visible) {
+                        chipData.push({
+                            icon: child.icon ? child.icon : null,
+                            value: childColumn.title,
+                            obj: child.obj ? child.obj : null,
+                            id: childColumn.name,
+                        });
+                    }
+                    // if column is not visible it means it has been removed, do not push anything
+                } else {
+                    chipData.push({
+                        icon: child.icon ? child.icon : null,
+                        value: '*Not found!',
+                        obj: child.obj ? child.obj : null,
+                        id: '*NOTFND',
+                    });
+                }
             }
             chipProps.dataSet = { initialData: [...chipData] };
             chipProps.data = chipData;


### PR DESCRIPTION
Column menu chip showed even if column was removed or hidden; this error can be fixed by skipping columns that are not visible. 