### PR TITLE
fix: LS25003825: initial options as data cell

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1919,8 +1919,8 @@ export class KupInputPanel {
             return adapter(options, currentValue);
         } else {
             return options.map((option) => ({
-                value: option.label,
-                id: option.id,
+                value: option.value,
+                id: option.obj.k,
                 selected: currentValue === option.id,
             }));
         }

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -1921,7 +1921,7 @@ export class KupInputPanel {
             return options.map((option) => ({
                 value: option.value,
                 id: option.obj.k,
-                selected: currentValue === option.id,
+                selected: currentValue === option.obj.k,
             }));
         }
     }


### PR DESCRIPTION
The Respective PRs on [kokos-sdk-java-rpgle](https://github.com/smeup/kokos-sdk-java-rpgle/pull/769) and [as400 proxy](https://github.com/smeup/kokos-me-java-as400proxy/pull/226) need to be approved before this one

This PR changes the way initial options are fetched and interpreted.

Now the data passed is in a Cell array format and not in an { id: ... , label: .... } format