### PR TITLE
fix: LS25003903: removed totals matrix logics

### DIFF
--- a/packages/ketchup-react/components.ts
+++ b/packages/ketchup-react/components.ts
@@ -451,7 +451,8 @@ type KupDataTableEvents = {
     onKupDatatableCellInput: EventName<KupDataTableCustomEvent<FCellEventPayload>>,
     onKupDatatableObjectfieldSearchpayload: EventName<KupDataTableCustomEvent<FObjectFieldEventPayload>>,
     onKupDatatableObjectfieldOpensearchmenu: EventName<KupDataTableCustomEvent<FObjectFieldEventPayload>>,
-    onKupDatatableObjectfieldSelectedmenuitem: EventName<KupDataTableCustomEvent<FObjectFieldEventPayload>>
+    onKupDatatableObjectfieldSelectedmenuitem: EventName<KupDataTableCustomEvent<FObjectFieldEventPayload>>,
+    onKupDatatableTotalsMatrix: EventName<CustomEvent<string>>
 };
 
 export const KupDataTable: StencilReactComponent<KupDataTableElement, KupDataTableEvents> = /*@__PURE__*/ createComponent<KupDataTableElement, KupDataTableEvents>({
@@ -486,7 +487,8 @@ export const KupDataTable: StencilReactComponent<KupDataTableElement, KupDataTab
         onKupDatatableCellInput: 'kup-datatable-cell-input',
         onKupDatatableObjectfieldSearchpayload: 'kup-datatable-objectfield-searchpayload',
         onKupDatatableObjectfieldOpensearchmenu: 'kup-datatable-objectfield-opensearchmenu',
-        onKupDatatableObjectfieldSelectedmenuitem: 'kup-datatable-objectfield-selectedmenuitem'
+        onKupDatatableObjectfieldSelectedmenuitem: 'kup-datatable-objectfield-selectedmenuitem',
+        onKupDatatableTotalsMatrix: 'kup-datatable-totals-matrix'
     } as KupDataTableEvents,
     defineCustomElement: defineKupDataTable
 });

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -1917,7 +1917,6 @@ export namespace Components {
           * Sets the width of the table.
          */
         "tableWidth": string;
-        "toggleTotalsMatrix": (columnName?: string, calculateTotals?: boolean) => Promise<void>;
         /**
           * This method is used to force tooltip request for current focused cell
          */
@@ -5549,6 +5548,7 @@ declare global {
         "kup-datatable-objectfield-searchpayload": FObjectFieldEventPayload;
         "kup-datatable-objectfield-opensearchmenu": FObjectFieldEventPayload;
         "kup-datatable-objectfield-selectedmenuitem": FObjectFieldEventPayload;
+        "kup-datatable-totals-matrix": string;
     }
     interface HTMLKupDataTableElement extends Components.KupDataTable, HTMLStencilElement {
         addEventListener<K extends keyof HTMLKupDataTableElementEventMap>(type: K, listener: (this: HTMLKupDataTableElement, ev: KupDataTableCustomEvent<HTMLKupDataTableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -7883,6 +7883,7 @@ declare namespace LocalJSX {
           * Event fired when the save button is pressed.
          */
         "onKup-datatable-save"?: (event: KupDataTableCustomEvent<KupDatatableInsertRowEventPayload>) => void;
+        "onKup-datatable-totals-matrix"?: (event: KupDataTableCustomEvent<string>) => void;
         /**
           * Event fired when the user click on update button or on one of the command buttons. Update button and commands are visible when the props updatableData is true
          */

--- a/packages/ketchup/src/components/kup-card/standard/kup-card-standard.tsx
+++ b/packages/ketchup/src/components/kup-card/standard/kup-card-standard.tsx
@@ -894,17 +894,6 @@ export function create12(component: KupCard): VNode {
                             )}
                         />
                     ) : null}
-                    {buttonsIds.includes(
-                        KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE
-                    ) ? (
-                        <kup-button
-                            {...buttonArray.find(
-                                (x) =>
-                                    x.id ===
-                                    KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE
-                            )}
-                        />
-                    ) : null}
                 </div>
             ) : null}
             <div
@@ -1262,17 +1251,6 @@ export function create14(component: KupCard): VNode {
                                         (x) =>
                                             x.id ===
                                             KupColumnMenuIds.TOTALS_TABLE
-                                    )}
-                                />
-                            ) : null}
-                            {buttonsIds.includes(
-                                KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE
-                            ) ? (
-                                <kup-button
-                                    {...buttonArray.find(
-                                        (x) =>
-                                            x.id ===
-                                            KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE
                                     )}
                                 />
                             ) : null}

--- a/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
+++ b/packages/ketchup/src/utils/kup-column-menu/kup-column-menu.ts
@@ -237,19 +237,6 @@ export class KupColumnMenu {
                         KupLanguageGeneric.TOTALS_TABLE
                     ),
                 });
-                if (comp.totalsMatrixView) {
-                    props.push({
-                        className: 'printable',
-                        'data-storage': {
-                            columnName: column.name,
-                        },
-                        icon: 'table-large',
-                        id: KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE,
-                        title: dom.ketchup.language.translate(
-                            KupLanguageGeneric.BACK_TO_ORIGINAL_TABLE
-                        ),
-                    });
-                }
             }
         }
         return props;
@@ -822,18 +809,9 @@ export class KupColumnMenu {
                         break;
                     case KupColumnMenuIds.TOTALS_TABLE:
                         comp.closeColumnMenu().then(() => {
-                            (comp as KupDataTable).toggleTotalsMatrix(
-                                columnName,
-                                true
-                            );
-                        });
-                        break;
-                    case KupColumnMenuIds.BACK_TO_ORIGINAL_TABLE:
-                        comp.closeColumnMenu().then(() => {
-                            (comp as KupDataTable).toggleTotalsMatrix(
-                                columnName,
-                                false
-                            );
+                            (
+                                comp as KupDataTable
+                            ).kupDataTableTotalsMatrixRequest.emit(columnName);
                         });
                         break;
                 }


### PR DESCRIPTION
This PR removes the logics for the totals matrix, now moved to webupjs.

Now clicking on the totals button in column menu simply launches an event with the clicked column name as payload