### PR TITLE
feat: LS25003983: added pendingRowsToUpdate state attribute

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table-state.ts
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table-state.ts
@@ -1,3 +1,4 @@
+import { KupDataRow } from '../../components';
 import { GenericFilter } from '../../utils/filters/filters-declarations';
 import { KupState } from '../kup-state/kup-state';
 
@@ -43,6 +44,7 @@ export class KupDataTableState implements KupState {
     totals: TotalsMap;
     load: boolean = false;
     visibleColumns: string[] = undefined;
+    pendingRowsToUpdate: KupDataRow[] = [];
 
     public toDebugString() {
         // TODO

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -1142,8 +1142,6 @@ export class KupDataTable {
     #lastFocusedRow: KupDataTableRow = null;
     #maxRowsPerPage: number;
 
-    #pendingRowsToUpdate: KupDataRow[] = [];
-
     #readyPromise: Promise<void>;
     #readyResolve: () => void;
 


### PR DESCRIPTION
This PR is a preparation for a bigger set of changes that will be released in webupjs.

This new pendingRowsToUpdate state will contain the rows that encountered an error when executing an exu UPDATE, but why not pass them directly in data?
Because they will be added into originalDataLoaded variable and into the kupUpdate payload, even if the backend update failed, ruining the BEFORE part of the fun with non-updated data.
