### PR TITLE
LS26001308: kup-data-table: fix group and sort date column

### DIFF
--- a/packages/ketchup/src/managers/kup-data/kup-data-cell-helper.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data-cell-helper.ts
@@ -59,13 +59,11 @@ export function getCellValue(
         values.sort((n1, n2) => {
             return compareValues(
                 n1.obj,
-                kupObjects.isDate(n1.obj) || kupObjects.isNumber(n1.obj)
-                    ? n1.value
-                    : getValueForDisplay2(n1, column),
+                n1.value,
+                getValueForDisplay2(n1, column),
                 n2.obj,
-                kupObjects.isDate(n2.obj) || kupObjects.isNumber(n2.obj)
-                    ? n2.value
-                    : getValueForDisplay2(n2, column),
+                n2.value,
+                getValueForDisplay2(n2, column),
                 SortMode.A
             );
         });

--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -137,9 +137,11 @@ export function compareCell(
 ): number {
     return compareValues(
         cell1.obj,
-        cell1.decode ?? cell1.value,
+        cell1.value,
+        cell1.decode,
         cell2.obj,
-        cell2.decode ?? cell2.value,
+        cell2.value,
+        cell2.decode,
         sortMode
     );
 }
@@ -147,8 +149,10 @@ export function compareCell(
 export function compareValues(
     obj1: any,
     value1: any,
+    decode1: any,
     obj2: any,
     value2: any,
+    decode2: any,
     sortMode: SortMode
 ): number {
     const sm = sortMode === 'A' ? 1 : -1;
@@ -166,8 +170,8 @@ export function compareValues(
         return compare * sm;
     }
 
-    let s1: string = value1;
-    let s2: string = value2;
+    let s1: string = decode1 ?? value1;
+    let s2: string = decode2 ?? value2;
 
     if (s1 == s2) {
         return 0;
@@ -184,14 +188,14 @@ export function compareValues(
     let v1: any = s1;
     let v2: any = s2;
     if (dom.ketchup.objects.isNumber(obj1)) {
-        v1 = dom.ketchup.math.numberifySafe(s1);
-        v2 = dom.ketchup.math.numberifySafe(s2);
+        v1 = dom.ketchup.math.numberifySafe(value1);
+        v2 = dom.ketchup.math.numberifySafe(value2);
     } else if (dom.ketchup.objects.isDate(obj1)) {
         const firstDateValue = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s1, KupDatesFormats.ISO_DATE)
+            dom.ketchup.dates.format(value1, KupDatesFormats.ISO_DATE)
         );
         const secondDateValue = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s2, KupDatesFormats.ISO_DATE)
+            dom.ketchup.dates.format(value2, KupDatesFormats.ISO_DATE)
         );
         if (firstDateValue && secondDateValue) {
             v1 = firstDateValue;
@@ -202,19 +206,19 @@ export function compareValues(
         // returns an invalid date when it tries to parse a time
         // This solution is simpler and it works because the time format
         // was assumed to be equals to HH:mm:ss or HH:mm
-        const firstTimeValue = Number(s1.replace(/:/g, ''));
-        const secondTimeValue = Number(s2.replace(/:/g, ''));
+        const firstTimeValue = Number(value1.replace(/:/g, ''));
+        const secondTimeValue = Number(value2.replace(/:/g, ''));
         if (!Number.isNaN(firstTimeValue) && !Number.isNaN(secondTimeValue)) {
             v1 = firstTimeValue;
             v2 = secondTimeValue;
         }
     } else if (dom.ketchup.objects.isTimestamp(obj1)) {
         const firstTimestampValue = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s1, KupDatesFormats.ISO_DATE),
+            dom.ketchup.dates.format(value1, KupDatesFormats.ISO_DATE),
             KupDatesFormats.ISO_DATE_TIME
         );
         const secondTimestampValue = dom.ketchup.dates.toDate(
-            dom.ketchup.dates.format(s2, KupDatesFormats.ISO_DATE),
+            dom.ketchup.dates.format(value2, KupDatesFormats.ISO_DATE),
             KupDatesFormats.ISO_DATE_TIME
         );
         if (firstTimestampValue && secondTimestampValue) {


### PR DESCRIPTION
This pull request refactors how cell values are compared and sorted in the Ketchup data utilities, aiming to clarify and standardize the use of raw and decoded values during sorting and comparison operations. The main improvements involve consistently passing both the raw and decoded values to comparison functions and ensuring that the correct value is used depending on the data type (number, date, time, etc.).

**Comparison and sorting logic improvements:**

* Updated `compareCell` and `compareValues` in `cell-utils.ts` to explicitly pass both `value` and `decode` fields, rather than using a fallback with `??`, making the logic clearer and more predictable.
* Changed the string comparison logic in `compareValues` to use `decode` if available, otherwise fallback to `value`, improving the handling of display vs. raw values.
* For number, date, time, and timestamp comparisons, now consistently use the raw `value` field for parsing and conversion, ensuring accurate type-specific comparisons. [[1]](diffhunk://#diff-cac10ccedbfb19cc7c17fc8dfd3fc0ec91ca968569e2aac9c6352f170c2ef547L187-R198) [[2]](diffhunk://#diff-cac10ccedbfb19cc7c17fc8dfd3fc0ec91ca968569e2aac9c6352f170c2ef547L205-R221)

**Sorting helper adjustments:**

* Simplified the sorting logic in `kup-data-cell-helper.ts` to always pass both `value` and the result of `getValueForDisplay2` to `compareValues`, removing conditional logic based on type checks.