### PR TITLE
INP: Avoid command presence to map btn

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -875,8 +875,8 @@ export class KupInputPanel {
         const value = isFormattableType
             ? getCellValueForDisplay(column, cell)
             : cell.decode
-              ? cell.decode
-              : cell.value;
+            ? cell.decode
+            : cell.value;
 
         return (
             <span class={classList.join(' ')} id={column.name}>
@@ -1149,8 +1149,8 @@ export class KupInputPanel {
             +field.colSpan > 0
                 ? field.colSpan
                 : !(+field.colSpan > 0) && !(+field.colStart > 0)
-                  ? 1
-                  : null;
+                ? 1
+                : null;
 
         const colStart = colSpan ? `span ${colSpan}` : `${field.colStart}`;
 
@@ -1160,8 +1160,8 @@ export class KupInputPanel {
             +field.rowSpan > 0
                 ? field.rowSpan
                 : !(+field.rowSpan > 0) && !(+field.rowStart > 0)
-                  ? 1
-                  : null;
+                ? 1
+                : null;
 
         const rowStart = rowSpan ? `span ${rowSpan}` : `${field.rowStart}`;
 
@@ -1200,8 +1200,8 @@ export class KupInputPanel {
             length = fieldCell.cell.value
                 ? fieldCell.cell.value.length
                 : field.absoluteLength > 8
-                  ? field.absoluteLength
-                  : 8;
+                ? field.absoluteLength
+                : 8;
         } else {
             length = field.absoluteLength;
         }
@@ -1214,11 +1214,11 @@ export class KupInputPanel {
             fieldCell.cell.shape === FCellShapes.LABEL
                 ? getLabelAbsoluteWidth(length)
                 : fieldCell.cell.shape === FCellShapes.CHECKBOX
-                  ? 15
-                  : getAbsoluteWidth(
-                        length,
-                        graphicShapeHasIcon(fieldCell.cell.shape)
-                    );
+                ? 15
+                : getAbsoluteWidth(
+                      length,
+                      graphicShapeHasIcon(fieldCell.cell.shape)
+                  );
         const absoluteHeight = getAbsoluteHeight(field.absoluteHeight);
         const absoluteTop = getAbsoluteTop(
             field.absoluteRow,
@@ -1548,20 +1548,14 @@ export class KupInputPanel {
         };
 
         if (cell.data.mappedCommandId) {
-            const concurrentCommand = this.data.setup?.commands?.find(
-                (command) => command.value === cell.data.mappedCommandId
+            cell.isEditable = true;
+            cell.data.onClick = () => {
+                this.#getFunctionOnClickBTN(cell, cell.data.mappedCommandId);
+            };
+
+            this.data.setup.commands = this.data?.setup?.commands?.filter(
+                (command) => command.value !== cell.data.mappedCommandId
             );
-
-            if (concurrentCommand) {
-                cell.isEditable = true;
-                cell.data.onClick = () => {
-                    this.#getFunctionOnClickBTN(cell, concurrentCommand.value);
-                };
-
-                this.data.setup.commands = this.data.setup.commands.filter(
-                    (command) => command.value !== concurrentCommand.value
-                );
-            }
         }
 
         return {
@@ -2020,10 +2014,10 @@ export class KupInputPanel {
                     : cell.data?.data?.['kup-list'];
             if (kupListData) {
                 kupListData.data = filteredRows?.length
-                    ? (this.#optionsTreeComboAdapter(
+                    ? this.#optionsTreeComboAdapter(
                           visibleColumnsOptions,
                           cell.value
-                      ) ?? [])
+                      ) ?? []
                     : [];
                 kupListData.options = options?.columns ?? [];
             } else {
@@ -2096,10 +2090,10 @@ export class KupInputPanel {
                     // Update the autocomplete list data
                     const kupListData = targetCell.data.data['kup-list'];
                     kupListData.data = filteredRows.length
-                        ? (this.#optionsTreeComboAdapter(
+                        ? this.#optionsTreeComboAdapter(
                               visibleColumnsOptions,
                               cellValue
-                          ) ?? [])
+                          ) ?? []
                         : [];
                     kupListData.options = options.columns ?? [];
 


### PR DESCRIPTION
**Command handling improvements:**

* Simplified the logic for handling mapped commands by removing unnecessary lookups for the concurrent command and directly using `cell.data.mappedCommandId` for filtering and click handling.

