### PR TITLE
LS26001067: return default message on unknown date format

### DIFF
--- a/packages/ketchup/src/managers/kup-dates/kup-dates.ts
+++ b/packages/ketchup/src/managers/kup-dates/kup-dates.ts
@@ -901,7 +901,10 @@ export class KupDates {
         let date = this.toDate(
             this.normalize(value, KupDatesFormats.ISO_DATE_TIME)
         );
-        return date.toLocaleString(this.getLocale() + '-u-hc-h23', options);
+        return (
+            date?.toLocaleString(this.getLocale() + '-u-hc-h23', options) ??
+            `cannot format date time: ${value}`
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request makes a small but important improvement to the `KupDates` date formatting logic. The change ensures that if the date parsing fails and returns `null` or `undefined`, the method will now return a clear error message instead of causing a runtime error.

- Improved robustness of the `toLocaleString` call in the `KupDates` class: If the date cannot be parsed, the method now returns a descriptive error message instead of throwing an exception.