### PR TITLE
fix: LS26001370: avoid tbl droparea to go out the screen

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-drag-drop.scss
+++ b/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-drag-drop.scss
@@ -14,15 +14,18 @@ th[#{$kup-dd-draggable}] {
 }
 
 .droparea {
+  position: absolute;
   animation: fade-in 0.25s ease-out;
   background: var(--kup_datatable_background_color);
   border-radius: 8px;
   box-shadow: var(--kup-box-shadow);
-  display: none;
+  display: flex;
+  opacity: 0;
   padding: 1em 0.5em;
+  transition: opacity 0.25s;
 
   &--visible {
-    display: flex;
+    opacity: 1;
   }
 
   &__groups {
@@ -42,7 +45,6 @@ th[#{$kup-dd-draggable}] {
     margin: 0 0.5em;
     opacity: 0.5;
     position: relative;
-    transition: opacity 0.25s;
     width: 50px;
 
     .f-image {


### PR DESCRIPTION
Changed display none -> flex behaviour for droparea visibility to a opacity 0 -> 1.

This works because kup-dynamic position calculates the droparea left distance when the droparea is still in display none (elements aligned vertically), then the "--visible" state changes the display from none to flex (elements aligned vertically), but the dynamic position does not retrigger its calculations.

The fix maintains the display to flex to make kup-dynamic position always calculate left correctly and visibility is simply toggled with opacity