### PR TITLE
LS26001602: Firefox vs Chrome max-height implementation

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.scss
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.scss
@@ -138,7 +138,9 @@
   }
 
   &.image-cell {
-    max-height: 100%;
+    // with value `max-content` Firefox will adapt dimension based on contained image; if 100% is used Firefox cannot calculate correct height and that leads wrong visualization of the cell, because it referes to parent height
+    // with Chrome we do not have this problem since it seems to be 'smarter' and is able to fallback to contente height if parent height is not determined (not explicitly set with a 'fixed' value)
+    max-height: max-content;
     .f-cell__content .imageWrapIcon {
       position: relative;
       width: 100%;


### PR DESCRIPTION
This pull request makes a targeted style adjustment to improve image cell rendering across browsers. The main change is updating the `max-height` property for `.image-cell` elements to ensure consistent visualization, particularly in Firefox.

- CSS Improvements for Cross-Browser Compatibility:
  * Changed `max-height` in the `.image-cell` class from `100%` to `max-content` in `f-cell.scss`, addressing a Firefox-specific rendering issue where images were not sized correctly due to parent height calculation.

I have tested visual correctness (to ensure compatibility is kept on Chrome) by hand (no visual regression test is available for this feature) then on Firefox, on different components that are currently using `f-cell`. I also ran `npm run e2e:run` locally avoid breaking some tests that could unwantedly depend on `f-cell` visibility/dimensions.