### PR TITLE
LS26001636: kup-data-table: safe management drop on data-table

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -2515,11 +2515,15 @@ export class KupDataTable {
                     {
                         drop: (e: DropEvent) => {
                             const draggedTh = e.relatedTarget as HTMLElement;
-                            const grouped = getColumnByName(
-                                this.getColumns(),
-                                draggedTh.dataset.column
-                            );
-                            this.#handleColumnGroup(grouped);
+                            if (draggedTh.dataset?.column) {
+                                const grouped = getColumnByName(
+                                    this.getColumns(),
+                                    draggedTh.dataset.column
+                                );
+                                if (grouped) {
+                                    this.#handleColumnGroup(grouped);
+                                }
+                            }
                             this.#tableRef.removeAttribute(kupDragActiveAttr);
                         },
                     }
@@ -2538,11 +2542,15 @@ export class KupDataTable {
                     {
                         drop: (e: DropEvent) => {
                             const draggedTh = e.relatedTarget as HTMLElement;
-                            const deleted = getColumnByName(
-                                this.getColumns(),
-                                draggedTh.dataset.column
-                            );
-                            this.hideColumn(deleted);
+                            if (draggedTh.dataset?.column) {
+                                const deleted = getColumnByName(
+                                    this.getColumns(),
+                                    draggedTh.dataset.column
+                                );
+                                if (deleted) {
+                                    this.hideColumn(deleted);
+                                }
+                            }
                             this.#tableRef.removeAttribute(kupDragActiveAttr);
                         },
                     }
@@ -6879,7 +6887,6 @@ export class KupDataTable {
 
     #handleChipsContextMenu(chipColumnName: string, e) {
         e.preventDefault();
-
         this.openColumnMenu(
             chipColumnName,
             `.chip[data-value="${chipColumnName}"]`

--- a/packages/ketchup/tsconfig.json
+++ b/packages/ketchup/tsconfig.json
@@ -12,7 +12,8 @@
         "noUnusedLocals": false,
         "noUnusedParameters": true,
         "resolveJsonModule": true,
-        "target": "es2017"
+        "target": "es2017",
+        "strict": false
     },
     "include": ["src", "types/jsx.d.ts"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
This pull request primarily improves the robustness of the column drag-and-drop functionality in the `kup-data-table` component by adding safety checks before performing column operations. Additionally, it disables TypeScript's strict mode in the project configuration.

**Column drag-and-drop improvements:**

* Added checks to ensure that a column exists before attempting to group or hide it during drag-and-drop operations in `kup-data-table.tsx`. This prevents potential errors when the dragged column is not found. [[1]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R2518-R2526) [[2]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R2545-R2553)

**TypeScript configuration:**

* Disabled TypeScript's `strict` mode in `tsconfig.json` to relax type checking across the project.

**Minor code cleanup:**

* Removed an unnecessary empty line in the `#handleChipsContextMenu` method for cleaner code.