### PR TITLE
LS26001650: f-cell: if decode is blank, maintain this value for cell

### DIFF
--- a/packages/ketchup/src/utils/cell-utils.ts
+++ b/packages/ketchup/src/utils/cell-utils.ts
@@ -22,12 +22,13 @@ export function getCellValueForDisplay(
     column: KupDataColumn,
     cell: KupDataCell
 ): string {
-    if (cell != null) {
-        if (cell.displayedValue != null) {
-            return cell.displayedValue;
-        }
+    if (!cell) {
+        return '';
     }
-    if (cell.decode) {
+    if (cell.displayedValue != null) {
+        return cell.displayedValue;
+    }
+    if (cell.decode != null && cell.decode != undefined) {
         return cell.decode;
     }
     let formattedValue = _getCellValueForDisplay(cell.value, column, cell);


### PR DESCRIPTION
This pull request makes a small but important change to the `getCellValueForDisplay` utility function. The update ensures that if the `cell` argument is missing or null, the function will immediately return an empty string instead of proceeding, which helps prevent potential runtime errors.

- Improved null checking:
  * Updated `getCellValueForDisplay` in `cell-utils.ts` to return an empty string when the `cell` parameter is falsy, improving robustness and preventing errors when `cell` is null or undefined.