### PR TITLE
fix: LS26001695: droparea pointer events

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-drag-drop.scss
+++ b/packages/ketchup/src/components/kup-data-table/styles/kup-data-table-drag-drop.scss
@@ -20,11 +20,13 @@ th[#{$kup-dd-draggable}] {
   box-shadow: var(--kup-box-shadow);
   display: flex;
   opacity: 0;
+  pointer-events: none;
   padding: 1em 0.5em;
   transition: opacity 0.25s ease-in-out;
 
   &--visible {
     opacity: 1;
+    pointer-events: auto;
   }
 
   &__groups {


### PR DESCRIPTION
This pull request makes a small improvement to the drag-and-drop behavior in the `kup-data-table` component's styles. The change ensures that the draggable table header is not interactive (doesn't receive pointer events) when it is hidden, and becomes interactive only when visible.

* Improved drag-and-drop interactivity:
  * [`kup-data-table-drag-drop.scss`](diffhunk://#diff-2de89047123291be4f4f3996cc7afb016c286243804dd9edb926f4140447264dR23-R29): Added `pointer-events: none;` to the draggable header by default and enabled `pointer-events: auto;` when the header is visible, preventing accidental interactions when the element is hidden.