### PR TITLE
feat: NC: allow datepicker to select dates out of month

### DIFF
--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-built-in-1.scss
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-built-in-1.scss
@@ -19,8 +19,10 @@
   background-color: var(--kup_card_background_color);
   border-radius: var(--kup-radius-00);
   box-sizing: border-box;
-  box-shadow: 0 2px 1px -1px rgba(128, 128, 128, 0.1),
-    0 1px 1px 0 rgba(128, 128, 128, 0.1), 0 1px 3px 0 rgba(128, 128, 128, 0.6);
+  box-shadow:
+    0 2px 1px -1px rgba(128, 128, 128, 0.1),
+    0 1px 1px 0 rgba(128, 128, 128, 0.1),
+    0 1px 3px 0 rgba(128, 128, 128, 0.6);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -111,6 +113,11 @@
   .item-disabled {
     .item-number {
       color: var(--kup-text-disabled);
+      cursor: pointer;
+
+      &:hover {
+        background-color: var(--kup_card_selected_color_hover);
+      }
     }
   }
 

--- a/packages/ketchup/src/components/kup-card/built-in/kup-card-calendar.tsx
+++ b/packages/ketchup/src/components/kup-card/built-in/kup-card-calendar.tsx
@@ -4,15 +4,11 @@ import {
     FButtonProps,
     FButtonStyling,
 } from '../../../f-components/f-button/f-button-declarations';
-import {
-    KupDateTimeFormatOptionsMonth,
-    KupDatesFormats,
-} from '../../../managers/kup-dates/kup-dates-declarations';
+import { KupDateTimeFormatOptionsMonth } from '../../../managers/kup-dates/kup-dates-declarations';
 import {
     KupDom,
     KupManager,
 } from '../../../managers/kup-manager/kup-manager-declarations';
-import { KupObj } from '../../../managers/kup-objects/kup-objects-declarations';
 import { SourceEvent } from '../../kup-date-picker/kup-date-picker-declarations';
 import { KupCard } from '../kup-card';
 import {
@@ -260,16 +256,31 @@ function createDaysCalendar(component: KupCard) {
     let daysForRowAdded = 0;
     const showPreviousNextMonthDays = isShowPreviousNextMonthDays(component);
     let substractDays = 0;
+
+    const prevMonth = lastPreviousMonthDate.getMonth(); // già il mese corretto
+    const prevYear = lastPreviousMonthDate.getFullYear();
+
     while (!finish) {
         if (currentDayIndex == firstMonthDayIndex) {
             break;
         }
+        const prevDay = lastPreviousMonthDate.getDate() - substractDays++;
+        const prevDataIndex =
+            prevYear.toString() +
+            '-' +
+            fillString((prevMonth + 1).toString(), '0', 2, true) +
+            '-' +
+            fillString(prevDay.toString(), '0', 2, true);
+
         row.unshift(
             <td class="item-disabled">
-                <span class="item-number">
-                    {showPreviousNextMonthDays
-                        ? lastPreviousMonthDate.getDate() - substractDays++
-                        : ''}
+                <span
+                    class="item-number"
+                    onClick={() =>
+                        onCalendarItemClick(component, prevDataIndex)
+                    }
+                >
+                    {showPreviousNextMonthDays ? prevDay : ''}
                 </span>
             </td>
         );
@@ -331,11 +342,30 @@ function createDaysCalendar(component: KupCard) {
             }
         }
         let nextMonthDay = 1;
+
+        // Il mese successivo: se selectedMonth è 11, si va a gennaio dell'anno dopo
+        const nextMonthNum = selectedMonth === 11 ? 0 : selectedMonth + 1;
+        const nextYearNum =
+            selectedMonth === 11 ? selectedYear + 1 : selectedYear;
+
         for (let i = currentRowLastItem + 1; i < 7; i++) {
+            const nextDay = nextMonthDay++;
+            const nextDateIndex =
+                nextYearNum.toString() +
+                '-' +
+                fillString((nextMonthNum + 1).toString(), '0', 2, true) +
+                '-' +
+                fillString(nextDay.toString(), '0', 2, true);
+
             row.push(
                 <td class="item-disabled">
-                    <span class="item-number">
-                        {showPreviousNextMonthDays ? nextMonthDay++ : ''}
+                    <span
+                        class="item-number"
+                        onClick={() =>
+                            onCalendarItemClick(component, nextDateIndex)
+                        }
+                    >
+                        {showPreviousNextMonthDays ? nextDay : ''}
                     </span>
                 </td>
             );


### PR DESCRIPTION
This pull request enhances the calendar functionality in the `kup-card` built-in component and improves the user experience for disabled calendar days. The main changes include making the days from the previous and next months clickable, updating their visual feedback on hover, and cleaning up unused imports.

**Calendar functionality improvements:**

* Made days from the previous and next months clickable by adding `onClick` handlers to their calendar cells, allowing users to select these days (`kup-card-calendar.tsx`). [[1]](diffhunk://#diff-aec218139857b1994349197c31416978e8f9db5230d2c13fd64c7a6ebc709a75R259-R283) [[2]](diffhunk://#diff-aec218139857b1994349197c31416978e8f9db5230d2c13fd64c7a6ebc709a75R345-R368)

**User interface enhancements:**

* Added a pointer cursor and a background color change on hover for disabled days (`.item-disabled .item-number`) in the calendar, providing better visual feedback to users (`kup-card-built-in-1.scss`).

**Code cleanup:**

* Removed unused imports from `kup-card-calendar.tsx` to streamline the codebase.

**Minor formatting:**

* Minor formatting adjustment to the `box-shadow` property in the SCSS file for consistency.