### PR TITLE
Remove shared sheet when no managed component

### DIFF
--- a/packages/ketchup/src/managers/kup-theme/kup-theme.ts
+++ b/packages/ketchup/src/managers/kup-theme/kup-theme.ts
@@ -226,6 +226,19 @@ export class KupTheme {
             sheet.replaceSync(this.getSharedStyle(tagName as KupTagNames));
         });
     }
+    private hasManagedComponentForTag(tagName: KupTagNames): boolean {
+        for (const comp of this.managedComponents) {
+            const compTagName = comp.tagName as KupTagNames;
+            if (
+                compTagName === tagName &&
+                this.adoptedStyleSheetsTargets.has(compTagName) &&
+                comp.isConnected
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
     /**
      * Sets the theme using this.name or the function's argument.
      * @param {string} name - When present, this theme will be set.
@@ -321,6 +334,13 @@ export class KupTheme {
             this.managedComponents.delete(
                 comp.rootElement ? comp.rootElement : comp
             );
+        }
+
+        if (this.supportsConstructable) {
+            const tagName: KupTagNames = comp.tagName as KupTagNames;
+            if (!this.hasManagedComponentForTag(tagName)) {
+                this.sharedSheets.delete(tagName);
+            }
         }
     }
     /**


### PR DESCRIPTION
Add hasManagedComponentForTag to check if any managed component with the given tag is currently connected and using adoptedStyleSheetsTargets. When supportsConstructable is true, remove the tag's entry from sharedSheets after a component is detached if no other managed component remains. This cleans up unused constructable stylesheets for tags when the last managed component is disconnected.