### PR TITLE
Fix some causes of memorr leaks

### DIFF
--- a/packages/ketchup/src/components/kup-box/kup-box.tsx
+++ b/packages/ketchup/src/components/kup-box/kup-box.tsx
@@ -2199,7 +2199,9 @@ export class KupBox {
 
     disconnectedCallback() {
         this.#kupManager.interact.unregister(
-            this.interactableDrag.concat(this.interactableDrop)
+            this.interactableDrag
+                .concat(this.interactableDrop)
+                .concat(this.interactableTouch)
         );
         this.#kupManager.language.unregister(this);
         this.#kupManager.theme.unregister(this);

--- a/packages/ketchup/src/components/kup-card/kup-card.tsx
+++ b/packages/ketchup/src/components/kup-card/kup-card.tsx
@@ -38,6 +38,7 @@ import {
     KupCardClickPayload,
     KupCardColorPickerOptions,
 } from './kup-card-declarations';
+import { KupDynamicPositionElement } from '../../managers/kup-dynamic-position/kup-dynamic-position-declarations';
 import { FImage } from '../../f-components/f-image/f-image';
 import { KupDebugCategory } from '../../managers/kup-debug/kup-debug-declarations';
 import { KupLanguageGeneric } from '../../managers/kup-language/kup-language-declarations';
@@ -670,6 +671,16 @@ export class KupCard {
     }
 
     disconnectedCallback() {
+        if (
+            (this.rootElement as KupDynamicPositionElement).kupDynamicPosition
+        ) {
+            this.kupManager.dynamicPosition.stop(
+                this.rootElement as KupDynamicPositionElement
+            );
+            this.kupManager.dynamicPosition.unregister([
+                this.rootElement as KupDynamicPositionElement,
+            ]);
+        }
         this.kupManager.interact.unregister([this.rootElement]);
         this.kupManager.language.unregister(this);
         this.kupManager.resize.unobserve(this.rootElement);

--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -2217,6 +2217,9 @@ export class KupDataTable {
         this.#kupManager.dynamicPosition.stop(
             this.#columnDropCard as KupDynamicPositionElement
         );
+        this.#kupManager.dynamicPosition.unregister([
+            this.#columnDropCard as KupDynamicPositionElement,
+        ]);
         this.#kupManager.removeClickCallback(this.#clickCbDropCard);
         this.#columnDropCard.remove();
         this.#columnDropCard = null;
@@ -3419,6 +3422,9 @@ export class KupDataTable {
         this.#kupManager.dynamicPosition.stop(
             this.#actionsCard as KupDynamicPositionElement
         );
+        this.#kupManager.dynamicPosition.unregister([
+            this.#actionsCard as KupDynamicPositionElement,
+        ]);
         this.#kupManager.removeClickCallback(this.#clickCbDropCard);
         this.#actionsCard.remove();
         this.#actionsCard = null;
@@ -4764,6 +4770,16 @@ export class KupDataTable {
 
     #closeTotalMenu() {
         this.openedTotalMenu = null;
+        const menu: HTMLKupListElement =
+            this.rootElement.shadowRoot?.querySelector('#totals-menu');
+        if (menu) {
+            this.#kupManager.dynamicPosition.stop(
+                menu as unknown as KupDynamicPositionElement
+            );
+            this.#kupManager.dynamicPosition.unregister([
+                menu as unknown as KupDynamicPositionElement,
+            ]);
+        }
         this.#kupManager.removeClickCallback(this.#clickCb);
     }
 
@@ -7754,6 +7770,32 @@ export class KupDataTable {
             this.#kupManager.dynamicPosition.unregister([
                 this.#customizeTopPanelRef,
             ]);
+        if (this.#columnDropCard) {
+            this.#kupManager.dynamicPosition.stop(
+                this.#columnDropCard as KupDynamicPositionElement
+            );
+            this.#kupManager.dynamicPosition.unregister([
+                this.#columnDropCard as KupDynamicPositionElement,
+            ]);
+        }
+        if (this.#actionsCard) {
+            this.#kupManager.dynamicPosition.stop(
+                this.#actionsCard as KupDynamicPositionElement
+            );
+            this.#kupManager.dynamicPosition.unregister([
+                this.#actionsCard as KupDynamicPositionElement,
+            ]);
+        }
+        const totalMenu: HTMLKupListElement =
+            this.rootElement.shadowRoot?.querySelector('#totals-menu');
+        if (totalMenu) {
+            this.#kupManager.dynamicPosition.stop(
+                totalMenu as unknown as KupDynamicPositionElement
+            );
+            this.#kupManager.dynamicPosition.unregister([
+                totalMenu as unknown as KupDynamicPositionElement,
+            ]);
+        }
         const dynamicPositionElements: NodeListOf<KupDynamicPositionElement> =
             this.rootElement.shadowRoot.querySelectorAll(
                 '[' + kupDynamicPositionAttribute + ']'

--- a/packages/ketchup/src/managers/kup-dynamic-position/kup-dynamic-position-declarations.ts
+++ b/packages/ketchup/src/managers/kup-dynamic-position/kup-dynamic-position-declarations.ts
@@ -27,6 +27,8 @@ export interface KupDynamicPositionElement extends HTMLElement {
         originalPath: HTMLElement[];
         placement: KupDynamicPositionPlacement;
         rAF: number;
+        /** Elements that had scroll reposition listeners actually attached. */
+        scrollListenerTargets?: HTMLElement[];
     };
 }
 /**

--- a/packages/ketchup/src/managers/kup-dynamic-position/kup-dynamic-position.ts
+++ b/packages/ketchup/src/managers/kup-dynamic-position/kup-dynamic-position.ts
@@ -131,8 +131,19 @@ export class KupDynamicPosition {
     unregister(elements: KupDynamicPositionElement[]): void {
         if (this.managedElements) {
             for (let index = 0; index < elements.length; index++) {
-                this.removeRepositionListeners(elements[index]);
-                this.managedElements.delete(elements[index]);
+                const el = elements[index];
+                this.removeRepositionListeners(el);
+                this.managedElements.delete(el);
+                // If the element was detached (moved to the global container),
+                // remove it from the container to avoid orphaned DOM nodes.
+                if (el?.kupDynamicPosition?.detach && el.parentElement === this.container) {
+                    this.container.removeChild(el);
+                }
+                // Sever all object references (originalPath, anchor, etc.)
+                // so the GC can collect detached ancestor nodes.
+                if (el) {
+                    el.kupDynamicPosition = null;
+                }
             }
         }
     }
@@ -350,32 +361,43 @@ export class KupDynamicPosition {
         window.addEventListener('scroll', repositionListener);
 
         if (el?.kupDynamicPosition?.anchor) {
+            const scrollTargets: HTMLElement[] = [];
             let container = this.getAnchorContainer(el);
 
-            this.updateEventListenerOnAncestors(container, (el) => {
-                if (this.isScrollable(el)) {
-                    el.addEventListener('scroll', repositionListener);
+            this.updateEventListenerOnAncestors(container, (ancestor) => {
+                if (this.isScrollable(ancestor)) {
+                    ancestor.addEventListener('scroll', repositionListener);
+                    scrollTargets.push(ancestor);
                 }
             });
+            // Store which ancestors received scroll listeners for reliable cleanup.
+            if (el.kupDynamicPosition) {
+                el.kupDynamicPosition.scrollListenerTargets = scrollTargets;
+            }
         }
         (el as any)._repositionListener = repositionListener;
     }
 
     removeRepositionListeners(el: KupDynamicPositionElement): void {
         const repositionListener = (el as any)._repositionListener;
+        if (!repositionListener) {
+            return;
+        }
 
         window.removeEventListener('resize', repositionListener);
         window.removeEventListener('scroll', repositionListener);
 
-        if (el?.kupDynamicPosition?.anchor) {
-            let container = this.getAnchorContainer(el);
-
-            this.updateEventListenerOnAncestors(container, (el) => {
-                if (this.isScrollable(el)) {
-                    el.removeEventListener('scroll', repositionListener);
-                }
-            });
+        // Use the stored list of scroll targets for reliable removal:
+        // re-evaluating isScrollable during teardown is unreliable because
+        // computed styles may have changed, causing listeners to leak.
+        const scrollTargets = el?.kupDynamicPosition?.scrollListenerTargets;
+        if (scrollTargets?.length) {
+            for (const target of scrollTargets) {
+                target.removeEventListener('scroll', repositionListener);
+            }
+            el.kupDynamicPosition.scrollListenerTargets = [];
         }
+
         delete (el as any)._repositionListener;
     }
 


### PR DESCRIPTION
This pull request focuses on improving the cleanup and lifecycle management of dynamically positioned UI elements in several Ketchup components. The main changes ensure that all event listeners and DOM references are properly removed when components are disconnected or elements are no longer needed, preventing memory leaks and orphaned DOM nodes. The changes also introduce more reliable tracking and removal of scroll event listeners for dynamic positioning.

**Dynamic Positioning and Cleanup Improvements:**

* Added explicit calls to `dynamicPosition.stop()` and `dynamicPosition.unregister()` for dynamically positioned elements (such as cards, menus, and panels) in `kup-card` and `kup-data-table` during component teardown to ensure proper cleanup. [[1]](diffhunk://#diff-1ad1db465c1a8be5e42658e41c95730495875b1f0c9fe335d25915a9eaf0cc3dR674-R683) [[2]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R2220-R2222) [[3]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R3425-R3427) [[4]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R4773-R4782) [[5]](diffhunk://#diff-409fe7830b5a5181f086e18e3c76fe8cbfce1a4e0936b936472667a83a284584R7773-R7798)
* Updated the `KupDynamicPosition.unregister()` method to remove detached elements from the global container, sever object references (like `originalPath` and `anchor`), and clear the `kupDynamicPosition` property, aiding garbage collection and preventing orphaned DOM nodes.
* Improved the way scroll event listeners are managed: when adding listeners, the code now tracks which ancestor elements actually received scroll listeners via a new `scrollListenerTargets` property, ensuring reliable and leak-free removal during cleanup. [[1]](diffhunk://#diff-c4c459b60674e42395da84f355067bb5c7f725e8e0d7ec717f74ba8f2ffc2942R30-R31) [[2]](diffhunk://#diff-48a92ecd4a475d1af4716942972c430d03d7017124b3d27252a633acc9c11218R364-R400)

**Codebase Consistency:**

* Updated imports to include the `KupDynamicPositionElement` type where needed, ensuring type safety and consistency.

**Interactable Cleanup:**

* In `kup-box`, extended the cleanup of interactable elements during disconnect to include touch interactions, not just drag and drop.