### PR TITLE
fix: manage inp tbl contextmenu as custom event

### DIFF
--- a/packages/ketchup-react/components.ts
+++ b/packages/ketchup-react/components.ts
@@ -799,7 +799,8 @@ type KupInputPanelEvents = {
     onKupInputpanelObjectfieldSearchpayload: EventName<KupInputPanelCustomEvent<FObjectFieldEventPayload>>,
     onKupInputpanelObjectfieldOpensearchmenu: EventName<KupInputPanelCustomEvent<FObjectFieldEventPayload>>,
     onKupInputpanelObjectfieldSelectedmenuitem: EventName<KupInputPanelCustomEvent<FObjectFieldEventPayload>>,
-    onKupInputpanelUpload: EventName<KupInputPanelCustomEvent<KupFileUploadEventPayload>>
+    onKupInputpanelUpload: EventName<KupInputPanelCustomEvent<KupFileUploadEventPayload>>,
+    onKupInputpanelDatatableContextmenu: EventName<KupInputPanelCustomEvent<KupDatatableClickEventPayload>>
 };
 
 export const KupInputPanel: StencilReactComponent<KupInputPanelElement, KupInputPanelEvents> = /*@__PURE__*/ createComponent<KupInputPanelElement, KupInputPanelEvents>({
@@ -813,7 +814,8 @@ export const KupInputPanel: StencilReactComponent<KupInputPanelElement, KupInput
         onKupInputpanelObjectfieldSearchpayload: 'kup-inputpanel-objectfield-searchpayload',
         onKupInputpanelObjectfieldOpensearchmenu: 'kup-inputpanel-objectfield-opensearchmenu',
         onKupInputpanelObjectfieldSelectedmenuitem: 'kup-inputpanel-objectfield-selectedmenuitem',
-        onKupInputpanelUpload: 'kup-inputpanel-upload'
+        onKupInputpanelUpload: 'kup-inputpanel-upload',
+        onKupInputpanelDatatableContextmenu: 'kup-inputpanel-datatable-contextmenu'
     } as KupInputPanelEvents,
     defineCustomElement: defineKupInputPanel
 });

--- a/packages/ketchup/src/components.d.ts
+++ b/packages/ketchup/src/components.d.ts
@@ -49,7 +49,7 @@ import { KupImageClickEventPayload } from "./components/kup-image/kup-image-decl
 import { KupImageListDataNode, KupImageListEventPayload } from "./components/kup-image-list/kup-image-list-declarations";
 import { KupTreeColumnMenuEventPayload, KupTreeColumnRemoveEventPayload, KupTreeContextMenuEventPayload, KupTreeDynamicMassExpansionEventPayload, KupTreeExpansionMode, KupTreeNode, KupTreeNodeButtonClickEventPayload, KupTreeNodeCollapseEventPayload, KupTreeNodeExpandEventPayload, KupTreeNodeSelectedEventPayload, TreeNodePath } from "./components/kup-tree/kup-tree-declarations";
 import { InputPanelButtonClickHandler, InputPanelCheckValidObjCallback, InputPanelCheckValidValueCallback, InputPanelOptionsHandler, KupInputPanelButtonsPositions, KupInputPanelClickEventPayload, KupInputPanelData, KupInputPanelPosition, KupInputPanelSubmit } from "./components/kup-input-panel/kup-input-panel-declarations";
-import { FObjectFieldEventPayload as FObjectFieldEventPayload1, KupFileUploadEventPayload as KupFileUploadEventPayload1 } from "./components";
+import { FObjectFieldEventPayload as FObjectFieldEventPayload1, KupDatatableClickEventPayload as KupDatatableClickEventPayload1, KupFileUploadEventPayload as KupFileUploadEventPayload1 } from "./components";
 import { KupLazyRender } from "./components/kup-lazy/kup-lazy-declarations";
 import { KupNavBarStyling } from "./components/kup-nav-bar/kup-nav-bar-declarations";
 import { KupNumericPickerEventPayload } from "./components/kup-numeric-picker/kup-numeric-picker-declarations";
@@ -111,7 +111,7 @@ export { KupImageClickEventPayload } from "./components/kup-image/kup-image-decl
 export { KupImageListDataNode, KupImageListEventPayload } from "./components/kup-image-list/kup-image-list-declarations";
 export { KupTreeColumnMenuEventPayload, KupTreeColumnRemoveEventPayload, KupTreeContextMenuEventPayload, KupTreeDynamicMassExpansionEventPayload, KupTreeExpansionMode, KupTreeNode, KupTreeNodeButtonClickEventPayload, KupTreeNodeCollapseEventPayload, KupTreeNodeExpandEventPayload, KupTreeNodeSelectedEventPayload, TreeNodePath } from "./components/kup-tree/kup-tree-declarations";
 export { InputPanelButtonClickHandler, InputPanelCheckValidObjCallback, InputPanelCheckValidValueCallback, InputPanelOptionsHandler, KupInputPanelButtonsPositions, KupInputPanelClickEventPayload, KupInputPanelData, KupInputPanelPosition, KupInputPanelSubmit } from "./components/kup-input-panel/kup-input-panel-declarations";
-export { FObjectFieldEventPayload as FObjectFieldEventPayload1, KupFileUploadEventPayload as KupFileUploadEventPayload1 } from "./components";
+export { FObjectFieldEventPayload as FObjectFieldEventPayload1, KupDatatableClickEventPayload as KupDatatableClickEventPayload1, KupFileUploadEventPayload as KupFileUploadEventPayload1 } from "./components";
 export { KupLazyRender } from "./components/kup-lazy/kup-lazy-declarations";
 export { KupNavBarStyling } from "./components/kup-nav-bar/kup-nav-bar-declarations";
 export { KupNumericPickerEventPayload } from "./components/kup-numeric-picker/kup-numeric-picker-declarations";
@@ -5823,6 +5823,7 @@ declare global {
         "kup-inputpanel-objectfield-opensearchmenu": FObjectFieldEventPayload1;
         "kup-inputpanel-objectfield-selectedmenuitem": FObjectFieldEventPayload1;
         "kup-inputpanel-upload": KupFileUploadEventPayload1;
+        "kup-inputpanel-datatable-contextmenu": KupDatatableClickEventPayload1;
     }
     interface HTMLKupInputPanelElement extends Components.KupInputPanel, HTMLStencilElement {
         addEventListener<K extends keyof HTMLKupInputPanelElementEventMap>(type: K, listener: (this: HTMLKupInputPanelElement, ev: KupInputPanelCustomEvent<HTMLKupInputPanelElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8954,6 +8955,7 @@ declare namespace LocalJSX {
           * Generic right click event on input panel.
          */
         "onKup-inputpanel-contextmenu"?: (event: KupInputPanelCustomEvent<KupInputPanelClickEventPayload>) => void;
+        "onKup-inputpanel-datatable-contextmenu"?: (event: KupInputPanelCustomEvent<KupDatatableClickEventPayload1>) => void;
         "onKup-inputpanel-objectfield-opensearchmenu"?: (event: KupInputPanelCustomEvent<FObjectFieldEventPayload1>) => void;
         "onKup-inputpanel-objectfield-searchpayload"?: (event: KupInputPanelCustomEvent<FObjectFieldEventPayload1>) => void;
         "onKup-inputpanel-objectfield-selectedmenuitem"?: (event: KupInputPanelCustomEvent<FObjectFieldEventPayload1>) => void;

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -18,6 +18,7 @@ import {
     KupAutocompleteEventPayload,
     KupComboboxIconClickEventPayload,
     KupDataCell,
+    KupDatatableClickEventPayload,
     KupDataTableDataset,
     KupDataTableRow,
     KupDropdownButtonEventPayload,
@@ -465,6 +466,14 @@ export class KupInputPanel {
         bubbles: true,
     })
     kupCellUpload: EventEmitter<KupFileUploadEventPayload>;
+
+    @Event({
+        eventName: 'kup-inputpanel-datatable-contextmenu',
+        composed: true,
+        cancelable: false,
+        bubbles: true,
+    })
+    kupInputPanelDataTableContextMenu: EventEmitter<KupDatatableClickEventPayload>;
     //#endregion
 
     //#region PRIVATE METHODS
@@ -851,6 +860,15 @@ export class KupInputPanel {
                     this.#manageTblItemClick(e);
                     e.preventDefault();
                     e.stopPropagation();
+                }}
+                onKup-datatable-contextmenu={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.kupInputPanelDataTableContextMenu.emit({
+                        comp: this,
+                        id: this.rootElement.id,
+                        details: e.detail.details,
+                    });
                 }}
             ></kup-data-table>
         );
@@ -2314,34 +2332,6 @@ export class KupInputPanel {
         };
     }
 
-    #didLoadInteractables() {
-        /** input panel unloaded meanwhile... */
-        if (!this.#formRef) return;
-
-        // this could seems like a duplication because this.#kupManager.interact.on already does it but removing this causes an error on righ-clicking a TBL cell with tooltip when set as shape of an input panel cell
-        this.#kupManager.interact.managedElements.add(this.#formRef);
-
-        const tapCb = (e: PointerEvent) => {
-            if (e.button == 2) {
-                const details = this.#getEventDetails(e);
-
-                if (details) {
-                    this.kupDataTableContextMenu.emit({
-                        comp: this,
-                        id: this.rootElement.id,
-                        details,
-                    });
-                }
-            }
-        };
-
-        this.#kupManager.interact.on(
-            this.#formRef,
-            KupPointerEventTypes.TAP,
-            tapCb
-        );
-    }
-
     #setFocusOnInputElement() {
         if (!this.#formRef) return;
 
@@ -2467,7 +2457,6 @@ export class KupInputPanel {
     }
 
     componentDidLoad() {
-        this.#didLoadInteractables();
         this.kupReady.emit({ comp: this, id: this.rootElement.id });
 
         this.#setFocusOnInputElement();

--- a/packages/ketchup/src/components/kup-input-panel/readme.md
+++ b/packages/ketchup/src/components/kup-input-panel/readme.md
@@ -31,6 +31,7 @@
 | --------------------------------------------- | ----------------------------------------- | --------------------------------------------- |
 | `kup-input-panel-ready`                       | When component load is complete           | `CustomEvent<KupEventPayload>`                |
 | `kup-inputpanel-contextmenu`                  | Generic right click event on input panel. | `CustomEvent<KupInputPanelClickEventPayload>` |
+| `kup-inputpanel-datatable-contextmenu`        |                                           | `CustomEvent<KupDatatableClickEventPayload>`  |
 | `kup-inputpanel-objectfield-opensearchmenu`   |                                           | `CustomEvent<FObjectFieldEventPayload>`       |
 | `kup-inputpanel-objectfield-searchpayload`    |                                           | `CustomEvent<FObjectFieldEventPayload>`       |
 | `kup-inputpanel-objectfield-selectedmenuitem` |                                           | `CustomEvent<FObjectFieldEventPayload>`       |


### PR DESCRIPTION
This pull request adds support for a new custom event, `kup-inputpanel-datatable-contextmenu`, to the `kup-input-panel` component, enabling consumers to handle context menu actions specifically triggered from the embedded `kup-data-table`. The implementation includes updates to both the Stencil component and its React wrapper, as well as documentation.

**Event Handling Enhancements:**

* Added a new event emitter `kupInputPanelDataTableContextMenu` to the `kup-input-panel` Stencil component, which emits `KupDatatableClickEventPayload` when a context menu action is triggered in the internal data table. [[1]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751R469-R476) [[2]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751R864-R872)
* Removed the old interactable event handler logic for context menu detection, streamlining how context menu events are handled within the component. [[1]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L2317-L2344) [[2]](diffhunk://#diff-3be3ab7bc856b40acafd35708b294693795918f6489927c11b4475c1b9380751L2470)

**React Wrapper Updates:**

* Updated the `KupInputPanelEvents` type and event mapping in the React wrapper to support the new `onKupInputpanelDatatableContextmenu` event. [[1]](diffhunk://#diff-12e77546f07f64b382b398ec8e093362d001c1f1cefcb762a74c715eea2a6096L802-R803) [[2]](diffhunk://#diff-12e77546f07f64b382b398ec8e093362d001c1f1cefcb762a74c715eea2a6096L816-R818)

**Documentation:**

* Added documentation for the new `kup-inputpanel-datatable-contextmenu` event to the component's README.