### PR TITLE
Use column metadata in cell type detection

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -4148,7 +4148,11 @@ export class KupDataTable {
         );
 
         const { cell, column, row } = details;
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const cellType = dom.ketchup.data.cell.getType(
+            column,
+            cell,
+            cell.shape
+        );
 
         if (!TypesToDuplicate.includes(cellType)) {
             return;

--- a/packages/ketchup/src/components/kup-form/kup-form.tsx
+++ b/packages/ketchup/src/components/kup-form/kup-form.tsx
@@ -567,6 +567,7 @@ export class KupForm {
         function setPlaceholderLabel() {
             switch (
                 dom.ketchup.data.cell.getType(
+                    column,
                     cell,
                     cell.shape || column.shape || null
                 )

--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -690,7 +690,7 @@ export class KupInputPanel {
             renderKup: true,
             setSizes: true,
         };
-        const label = this.#getLabelComponent(cell, column.title);
+        const label = this.#getLabelComponent(column, cell);
         const fcell = <FCell {...cellProps} />;
 
         if (label) {
@@ -885,12 +885,17 @@ export class KupInputPanel {
         );
     }
 
-    #getLabelComponent(cell: KupDataCell, label: string) {
+    #getLabelComponent(column: KupDataColumn, cell: KupDataCell) {
+        const label = column.title;
         if (!label) {
             return null;
         }
 
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const cellType = dom.ketchup.data.cell.getType(
+            column,
+            cell,
+            cell.shape
+        );
 
         if (cellType === FCellTypes.RADIO) {
             return <span>{label}</span>;
@@ -1312,6 +1317,7 @@ export class KupInputPanel {
         inpuPanelCells.map(({ cells }: InputPanelCells) =>
             cells.map(({ cell, column }) => {
                 const cellType = dom.ketchup.data.cell.getType(
+                    column,
                     cell,
                     cell.shape
                 );
@@ -1350,7 +1356,11 @@ export class KupInputPanel {
             id: column.name,
         };
 
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const cellType = dom.ketchup.data.cell.getType(
+            column,
+            cell,
+            cell.shape
+        );
         const { data, ...noDataProps } = cell.data || {};
 
         return cellType !== FCellTypes.MULTI_AUTOCOMPLETE &&
@@ -1450,7 +1460,7 @@ export class KupInputPanel {
             fieldLabel = col.title;
         }
         const currentValue = cell.value;
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const cellType = dom.ketchup.data.cell.getType(col, cell, cell.shape);
 
         const dataAdapterMap = new Map<FCellTypes, DataAdapterFn>([
             [FCellTypes.AUTOCOMPLETE, this.#CMBandACPAdapter.bind(this)],
@@ -1482,7 +1492,7 @@ export class KupInputPanel {
     }
 
     #slotData(cell: KupInputPanelCell, col: KupInputPanelColumn) {
-        const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+        const cellType = dom.ketchup.data.cell.getType(col, cell, cell.shape);
 
         if (cellType === FCellTypes.CHIP) {
             return {

--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -107,7 +107,7 @@ export const FCell: FunctionalComponent<FCellProps> = (
     let _value = cell.decode ?? cell.value;
 
     const valueToDisplay = props.previousValue !== _value ? _value : '';
-    const cellType = dom.ketchup.data.cell.getType(cell, shape);
+    const cellType = dom.ketchup.data.cell.getType(column, cell, shape);
     const sizing =
         props.density === 'extra_dense' ? 'extra-small' : cell.data?.sizing;
 
@@ -317,7 +317,7 @@ const mapData = (cell: KupDataCellOptions, column: KupDataColumn) => {
         ? cell.data.label
         : column.title;
     const currentValue = cell.value;
-    const cellType = dom.ketchup.data.cell.getType(cell, cell.shape);
+    const cellType = dom.ketchup.data.cell.getType(column, cell, cell.shape);
     const dataAdapterMap = new Map<FCellTypes, DataAdapterFn>([
         [FCellTypes.BUTTON_LIST, MainBTNAdapter.bind(this)],
         [FCellTypes.STRING, MainITXAdapter.bind(this)],

--- a/packages/ketchup/src/managers/kup-data/kup-data-declarations.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data-declarations.ts
@@ -44,6 +44,7 @@ export interface KupDataColumn {
     tooltip?: boolean;
     useAs?: UseAsValue;
     helper?: string;
+    maxLength?: number;
 }
 export interface KupDataColumnChild {
     name: string;

--- a/packages/ketchup/src/managers/kup-data/kup-data.ts
+++ b/packages/ketchup/src/managers/kup-data/kup-data.ts
@@ -82,8 +82,13 @@ export class KupData {
         ): KupDataCell[] {
             return replaceCell(dataset, cell, columns);
         },
-        getType(cell: KupDataCell, shape?: FCellShapes): FCellTypes {
+        getType(
+            column: KupDataColumn,
+            cell: KupDataCell,
+            shape?: FCellShapes
+        ): FCellTypes {
             const obj = cell.obj;
+            const maxLength = cell.data?.maxLength ?? column?.maxLength;
             if (shape) {
                 switch (shape.toUpperCase()) {
                     case FCellShapes.AUTOCOMPLETE:
@@ -179,7 +184,7 @@ export class KupData {
                 return FCellTypes.TIME;
             } else if (dom.ketchup.objects.isVoCodver(obj)) {
                 return FCellTypes.ICON;
-            } else if (cell.data?.maxLength >= 256) {
+            } else if (maxLength >= 256) {
                 return FCellTypes.MEMO;
             } else {
                 return FCellTypes.STRING;


### PR DESCRIPTION
Updated `dom.ketchup.data.cell.getType` to accept the column along with the cell, and propagated the new signature across data table, form, input panel, and f-cell call sites. Type inference now also considers `column.maxLength` (with cell-level override) when deciding MEMO vs STRING, and `maxLength` was added to `KupDataColumn` to support this metadata.