### PR TITLE
fix: tooltip in tbl new approach

### DIFF
--- a/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
+++ b/packages/ketchup/src/components/kup-input-panel/kup-input-panel.tsx
@@ -432,7 +432,7 @@ export class KupInputPanel {
         cancelable: false,
         bubbles: true,
     })
-    kupDataTableContextMenu: EventEmitter<KupInputPanelClickEventPayload>;
+    kupInputPanelContextMenu: EventEmitter<KupInputPanelClickEventPayload>;
 
     @Event({
         eventName: 'kup-inputpanel-objectfield-searchpayload',
@@ -2311,7 +2311,7 @@ export class KupInputPanel {
         const columnName = props.column.name;
 
         const anchor = fcell;
-        const cell = currState.rows[0].cells[columnName];
+        const cell = currState.rows[0].cells[columnName] ?? props?.cell;
         const column = currState.columns.find((c) => c.name == columnName);
         const row = currState.rows[0];
 
@@ -2336,7 +2336,7 @@ export class KupInputPanel {
                 const details = this.#getEventDetails(e);
 
                 if (details) {
-                    this.kupDataTableContextMenu.emit({
+                    this.kupInputPanelContextMenu.emit({
                         comp: this,
                         id: this.rootElement.id,
                         details,


### PR DESCRIPTION
This PR solves the issue for a tooltip in an input panel TBL cell

The approach is simplier and more correct than [the previous attempt](https://github.com/smeup/ketchup/pull/2876), that broke webupjs build

Tests on the INP and the Tooltip on webupjs pass correctly with these changes

The logic here leverages the props of the event emitted by the datatable, since it contains the cell.

When at line 2314 the cell is not found in the rows of the input panel (it will never happen since the column passed is a column of the data table and not of the INP) the cell passed in the props of the event is used, cell corresponding to the right clicked cell of the data table.

When the TBL is used inside an input panel (InputLegacy) the columns of the INP and the TBL will ALWAYS have different names, because otherwise the rpg code would not compile