### PR TITLE
fix: LS26002112: adapted tooltip default change

### DIFF
--- a/packages/ketchup/src/f-components/f-cell/f-cell.tsx
+++ b/packages/ketchup/src/f-components/f-cell/f-cell.tsx
@@ -167,7 +167,12 @@ export const FCell: FunctionalComponent<FCellProps> = (
         if (props.setSizes) {
             setCellSize(cellType, subcomponentProps, cell, props);
         }
-        classObj[FCellClasses.INDICATOR_TOPRIGHT] = cell.tooltip ?? false;
+        classObj[FCellClasses.INDICATOR_TOPRIGHT] =
+            column.tooltip === null ||
+            column.tooltip === undefined ||
+            column.tooltip === true
+                ? true
+                : false;
         content = setCell(
             cellType,
             subcomponentProps,


### PR DESCRIPTION
LS26002112: Scomparsi triangolini gialli in matrice Ketchup 

This pull request updates the logic for displaying the indicator in the top-right corner of cells in the `FCell` component. The new logic ensures that the indicator is shown only if the `column.tooltip` property is `null`, `undefined`, or `true`, making the behavior more consistent.

**Component behavior update:**

* Updated the assignment of `FCellClasses.INDICATOR_TOPRIGHT` in `FCell` to depend on the value of `column.tooltip`, showing the indicator only when `column.tooltip` is `null`, `undefined`, or `true`.