### PR TITLE
Bump GitHub Actions versions in workflows

### DIFF
--- a/.github/workflows/continuum.yaml
+++ b/.github/workflows/continuum.yaml
@@ -18,10 +18,10 @@ jobs:
     ketchup-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: '22.16.0'
                   cache: 'yarn'
@@ -42,7 +42,7 @@ jobs:
                   zip -qr /tmp/ketchup-components.zip ketchup/*
 
             - name: Setup AWS
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -55,9 +55,9 @@ jobs:
 
             # Prepare GitHub Pages Showcase deployment
             - name: Setup GitHub Pages
-              uses: actions/configure-pages@v5
+              uses: actions/configure-pages@v6
             - name: Upload GitHub Pages artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v5
               with:
                   path: './packages/ketchup-showcase/dist'
 
@@ -77,14 +77,14 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+            uses: actions/deploy-pages@v5
 
     build:
         runs-on: ubuntu-latest
         needs: ketchup-release
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+        - uses: actions/checkout@v5
+        - uses: actions/setup-node@v5
               with:
                   node-version: '20.17.0'
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/develop-release.yml
+++ b/.github/workflows/develop-release.yml
@@ -11,10 +11,10 @@ jobs:
   run-cicd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Trigger jenkins workflow
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: 'https://webuptest.smeup.com/jenkins/job/WebupKetchupOutsourcingPipeline/build?token=${{ secrets.JENKINS_WEBHOOK_TOKEN }}'
           method: 'GET'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
     ketchup-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: '22.16.0'
                   cache: 'yarn'
@@ -37,7 +37,7 @@ jobs:
                   zip -qr /tmp/ketchup-components.zip ketchup/*
 
             - name: Setup AWS
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -15,16 +15,16 @@ jobs:
     showcase-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: '22.16.0'
                   cache: 'yarn'
 
             - name: Cache Puppeteer
-              uses: actions/cache@v3
+              uses: actions/cache@v5
               with:
                   path: ~/.cache/puppeteer
                   key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/yarn.lock') }}
@@ -47,7 +47,7 @@ jobs:
                   zip -qr /tmp/ketchup-components.zip ketchup/*
 
             - name: Setup AWS
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -17,10 +17,10 @@ jobs:
             group: generate-docs-${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
         steps:
-            - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
               with:
                   node-version: '22.16.0'
                   cache: 'yarn'


### PR DESCRIPTION
Update CI/CD workflow dependencies to newer major versions across continuum, release, staging, develop-release, and unit-test pipelines. This includes actions/checkout, actions/setup-node, aws-actions/configure-aws-credentials, actions/cache, GitHub Pages actions, and fjogeleit/http-request-action to keep automation current and supported.