### PR TITLE
fix: NC: cell size and maxLength from column - release fix

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -3768,8 +3768,8 @@ export class KupDataTable {
             const columnName = td
                 ? td.dataset.column
                 : th
-                ? th.dataset.column
-                : null;
+                  ? th.dataset.column
+                  : null;
             if (columnName) {
                 column = getColumnByName(this.getColumns(), columnName);
             }
@@ -3779,10 +3779,10 @@ export class KupDataTable {
             area: isHeader
                 ? 'header'
                 : isBody
-                ? 'body'
-                : isFooter
-                ? 'footer'
-                : null,
+                  ? 'body'
+                  : isFooter
+                    ? 'footer'
+                    : null,
             cell: cell ? cell : null,
             column: column ? column : null,
             filterRemove: filterRemove ? filterRemove : null,
@@ -3840,10 +3840,10 @@ export class KupDataTable {
             area: isHeader
                 ? 'header'
                 : isBody
-                ? 'body'
-                : isFooter
-                ? 'footer'
-                : null,
+                  ? 'body'
+                  : isFooter
+                    ? 'footer'
+                    : null,
             cell: cell ? cell : null,
             column: column ? column : null,
             filterRemove: filterRemove ? filterRemove : null,
@@ -6225,6 +6225,16 @@ export class KupDataTable {
                         this.density === 'extra_dense'
                             ? 'extra-small'
                             : cell.data?.sizing,
+                    maxLength:
+                        cell.data?.maxLength !== null &&
+                        cell.data?.maxLength !== undefined
+                            ? cell.data['maxLength']
+                            : currentColumn?.['maxLength'],
+                    size:
+                        cell.data?.length !== null &&
+                        cell.data?.length !== undefined
+                            ? cell.data['length']
+                            : currentColumn?.['length'],
                 };
                 if (!cell.isEditable) {
                     cell.cssClass =
@@ -6239,14 +6249,15 @@ export class KupDataTable {
                         currentColumn,
                         row
                     ),
+
                     component: this,
                     density: this.density,
                     editable: this.editableData || this.updatableData,
                     indents: indend,
                     previousValue:
                         hideValuesRepetitions && previousRow
-                            ? previousRow.cells[name].decode ??
-                              previousRow.cells[name].value
+                            ? (previousRow.cells[name].decode ??
+                              previousRow.cells[name].value)
                             : undefined,
                     renderKup: this.lazyLoadCells,
                     cellActionIcon: this.#kupManager.data.cell.hasActionCell(


### PR DESCRIPTION
This pull request introduces enhancements to the `KupDataTable` component to improve how cell sizing and length constraints are handled. The changes ensure that the maximum length and size properties for table cells are set more robustly, falling back to column-level settings when not specified at the cell level.

**Enhancements to cell sizing and constraints:**

* Added logic to set `maxLength` and `size` properties for each cell, prioritizing cell-level values and falling back to column-level values if not present.