### PR TITLE
fix: LS26002468: forced strict equality check in row length

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -7052,7 +7052,7 @@ export class KupDataTable {
             newRow = this.#createRowWithInputFields();
         }
         Object.values(newRow.cells).forEach((cell) => {
-            if (selectedRows.length == 0 && !row) {
+            if (selectedRows.length === 0 && !row) {
                 cell.value = '';
             }
         });


### PR DESCRIPTION
This pull request makes a small code style improvement in the `KupDataTable` component. The equality comparison in a condition is updated to use the strict equality operator for better type safety.

* Changed the equality check in `kup-data-table.tsx` from `==` to `===` to enforce strict type comparison in the row cell value reset logic.