### PR TITLE
fix: LS26002468: insert row - reset initialValue and persist col data

### DIFF
--- a/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
+++ b/packages/ketchup/src/components/kup-data-table/kup-data-table.tsx
@@ -7054,6 +7054,9 @@ export class KupDataTable {
         Object.values(newRow.cells).forEach((cell) => {
             if (selectedRows.length === 0 && !row) {
                 cell.value = '';
+                if (cell?.data?.initialValue) {
+                    cell.data.initialValue = '';
+                }
             }
         });
         newRow.id = (
@@ -7073,13 +7076,15 @@ export class KupDataTable {
                       shape: c.shape ?? FCellShapes.TEXT_FIELD,
                       obj: { ...c.obj },
                       isEditable: c.isEditable ?? true,
-                      data:
-                          c['length'] && c['maxLength']
+                      data: {
+                          ...c?.['data'],
+                          ...(c['length'] && c['maxLength']
                               ? {
                                     size: c['length'],
                                     maxLength: c['maxLength'],
                                 }
-                              : {},
+                              : {}),
+                      },
                   };
             row.cells[c.name] = cell as KupDataCell;
         });


### PR DESCRIPTION
This pull request makes improvements to how cell data is managed when creating or resetting rows in the `KupDataTable` component. The main focus is on ensuring that both the `value` and the `initialValue` properties of cell data are correctly reset, and on preserving and extending cell data properties when constructing new cells.

**Cell data management improvements:**

* When resetting cell values, the code now also clears the `initialValue` property inside `cell.data` if it exists, ensuring that both the displayed value and its initial state are reset.
* When constructing new cells, the code now spreads existing properties from `c.data` into the new cell's `data` object, and conditionally adds `size` and `maxLength` properties if present, ensuring that all relevant cell data is preserved and extended as needed.